### PR TITLE
[WEBSITE-219] - Properly navigate to dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,15 @@
-node {
-  stage 'Checkout'
-  checkout scm
-  stage 'Build Docker Image'
-  docker.build('jenkinsciinfra/plugin-site')
+#!/usr/bin/env groovy
+
+node('docker') {
+
+  stage('Checkout') {
+    checkout scm
+  }
+
+  timestamps {
+    stage('Build Docker Image') {
+      docker.build('jenkinsciinfra/plugin-site')
+    }
+  }
+
 }

--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -60,6 +60,12 @@ class PluginDetail extends React.PureComponent {
     this.props.clearPlugin();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.params.pluginName !== nextProps.params.pluginName) {
+      this.props.getPlugin(nextProps.params.pluginName);
+    }
+  }
+
   closeDialog = (event) => {
     event && event.preventDefault();
     if (this.props.firstVisit) {


### PR DESCRIPTION
Related to issue # [WEBSITE-219]

Summary of this pull request: 

The plugin being displayed is in the redux state. This is loaded when
the component is mounted. The plugin to load is read via the router
parameter `pluginName`. But nothing was monitoring subsequent changes
to said parameter. The solution is to implement
`componentWillReceiveProps` and determine if the parameter has indeed
changed, and if so get the new plugin. This elegantly handles forward
and back navigation.