### PR TITLE
[FIX WEBSITE-223] - Show dependency titles vs names

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -30,6 +30,12 @@ class PluginDetail extends React.PureComponent {
       title: PropTypes.string
     })).isRequired,
     plugin: PropTypes.shape({
+      dependencies: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string,
+        title: PropTypes.string,
+        optional: PropTypes.bool,
+        version: PropTypes.string
+      })),
       excerpt: PropTypes.string,
       labels: PropTypes.arrayOf(PropTypes.string),
       maintainers: PropTypes.arrayOf(PropTypes.shape({
@@ -87,7 +93,7 @@ class PluginDetail extends React.PureComponent {
       const required = !dependency.optional ? 'required' : 'optional';
       return (
         <div key={dependency.name} className={required}>
-          <Link to={`/${dependency.name}`}>{dependency.name} v.{dependency.version} <span className="req">({required})</span></Link>
+          <Link to={`/${dependency.name}`}>{dependency.title} v.{dependency.version} <span className="req">({required})</span></Link>
         </div>
       );
     });


### PR DESCRIPTION
Related to issue [WEBSITE-223]

Summary of this pull request: 

Show dependency titles instead of names

<img width="1756" alt="dependencies" src="https://cloud.githubusercontent.com/assets/976479/20108584/8f0230ba-a5aa-11e6-8e89-617d1299cc2f.png">

This is dependent on the [PR](https://github.com/jenkins-infra/plugin-site-api/pull/8) in plugin-site-api project.
