### PR TITLE
[FIX WEBSITE-234] - Add support for displaying versions

### DIFF
--- a/views/partials/version.hbs
+++ b/views/partials/version.hbs
@@ -1,7 +1,3 @@
 <p>
-  Application Versions
-  <ul>
-    <li>plugin-site: '{{pluginSiteVersion}}'</li>
-    <li>plugin-site-api: '{{pluginSiteApiVersion}}'</li>
-  </ul>
+  UI <a href="https://github.com/jenkins-infra/plugin-site/commit/{{pluginSiteVersion}}">{{pluginSiteVersion}}</a> / API <a href="https://github.com/jenkins-infra/plugin-site-api/commit/{{pluginSiteApiVersion}}">{{pluginSiteApiVersion}}</a>
 </p>

--- a/views/partials/version.hbs
+++ b/views/partials/version.hbs
@@ -1,0 +1,7 @@
+<p>
+  Application Versions
+  <ul>
+    <li>plugin-site: '{{pluginSiteVersion}}'</li>
+    <li>plugin-site-api: '{{pluginSiteApiVersion}}'</li>
+  </ul>
+</p>


### PR DESCRIPTION
Related to issue [WEBSITE-234]

Summary of this pull request: 

If a file in the root directory is present with keys `plugin-site` and
`plugin-site-api` with their respective values being the short form of
the HEAD commit hash, the version partial will be injected into DOM
that's returned from jenkins.io

<img width="377" alt="screen shot 2016-11-15 at 11 42 21 am" src="https://cloud.githubusercontent.com/assets/976479/20314620/cd650408-ab28-11e6-9fbe-5b2d7510367b.png">

