### PR TITLE
[FIX WEBSITE-263] - Use 404 status code properly

### DIFF
--- a/server.js
+++ b/server.js
@@ -112,7 +112,8 @@ app.get('*', (req, res, next) => {
           </div>
         );
         const finalState = JSON.stringify(store.getState()).replace(/</g, '\\x3c');
-        res.status(200).render('index', {
+        const pluginNotFound = req.url !== '/' && store.getState().ui.plugin === null;
+        res.status(pluginNotFound ? 404 : 200).render('index', {
           rendered: rendered,
           reduxState: finalState,
           jsPath: jsPath,


### PR DESCRIPTION
Related to issue WEBSITE-263

Summary of this pull request: 

If a plugin doesn't exist return 404 along with the rendered NotFound
component.