### PR TITLE
[FIX WEBSITE-293] - Fix CSS import

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,6 +58,8 @@ const downloadHeader = () => {
           }
         });
         $('head').prepend('{{> header }}');
+        // Even though we're supplying our own this one still causes a conflict.
+        $('link[href="https://jenkins.io/css/font-icons.css"]').remove();
         $('head').append('<script>window.__REDUX_STATE__ = {{{reduxState}}};</script>');
         $('#grid-box').append('{{{rendered}}}');
         $('#grid-box').after('<script type="text/javascript" src="{{jsPath}}/main.js"></script>');


### PR DESCRIPTION
I think the issue is the user doesn't know we offer 2 different views for
displaying plugin search results because the CSS is (yet again) broken
because it's apparently a big deal to allow CORS for the fonts from the
plugin site to jenkins.io.