### PR TITLE
[FIX WEBSITE-277] - Show security warnings

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -163,7 +163,7 @@ class PluginDetail extends React.PureComponent {
     this.warningsModal.show();
   }
 
-  getWarnings(securityWarnings) {
+  getActiveWarnings(securityWarnings) {
     if (!securityWarnings) {
       return null;
     }
@@ -184,36 +184,32 @@ class PluginDetail extends React.PureComponent {
           </ModalView>
         </div>
       );
-    } else {
-      const renderedWarnings = securityWarnings.map(warning => {
-        const version = warning.firstVersion && warning.lastVersion
-          ? `versions ${warning.firstVersion} - ${warning.lastVersion}`
-          : `version ${warning.firstVersion ? warning.firstVersion : warning.lastVersion}`;
-        return (
-          <li key={warning.id}>
-            <h4>{warning.id}</h4>
-            <a href={warning.url}>{warning.message}</a> affecting {version}
-          </li>
-        )
-      });
-      return (
-        <div className="badge-box">
-          <span className="badge inactive warning" onClick={this.showWarnings}></span>
-          <ModalView hideOnOverlayClicked ignoreEscapeKey ref={(modal) => { this.warningsModal = modal; }}>
-            <Header>
-              <div>Previous Security Warnings</div>
-            </Header>
-            <Body>
-              <div>
-                <ul>
-                  {renderedWarnings}
-                </ul>
-              </div>
-            </Body>
-          </ModalView>
-        </div>
-      )
     }
+  }
+
+  getInactiveWarnings(securityWarnings) {
+    if (!securityWarnings || securityWarnings.length == 0) {
+      return null;
+    }
+    const renderedWarnings = securityWarnings.map(warning => {
+      const version = warning.firstVersion && warning.lastVersion
+        ? `versions ${warning.firstVersion} - ${warning.lastVersion}`
+        : `version ${warning.firstVersion ? warning.firstVersion : warning.lastVersion}`;
+      return (
+        <li key={warning.id}>
+          <h7>{warning.id}</h7>
+          <p><a href={warning.url}>{warning.message}</a> affecting {version}</p>
+        </li>
+      )
+    });
+    return (
+      <div>
+        <h6>Previous Security Warnings</h6>
+        <ul>
+          {renderedWarnings}
+        </ul>
+      </div>
+    )
   }
 
   render() {
@@ -238,7 +234,7 @@ class PluginDetail extends React.PureComponent {
                 <div className="container-fluid padded">
                   <h1 className="title">
                     {cleanTitle(plugin.title)}
-                    {this.getWarnings(plugin.securityWarnings)}
+                    {this.getActiveWarnings(plugin.securityWarnings)}
                     <span className="v">{plugin.version}</span>
                     <span className="sub">Minimum Jenkins requirement: {plugin.requiredCore}</span>
                     <span className="sub">ID: {plugin.name}</span>
@@ -283,6 +279,7 @@ class PluginDetail extends React.PureComponent {
                   <h6>Are you maintaining this plugin?</h6>
                   <p>Visit the <a href={plugin.wiki.url} target="_wiki">Jenkins Plugin Wiki</a> to edit this content.</p>
                 </div>
+                {this.getInactiveWarnings(plugin.securityWarnings)}
               </div>
             </div>
           </div>

--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -268,6 +268,27 @@ transform: scale(-1, 1);
 .modalview > .dialog > .content {padding:0 !important; max-height:100% !important;}
 .modalview > .dialog > .content .title {margin-bottom:2rem; vertical-align:top}
 .modalview > .dialog > .content .content {min-height:25rem}
+.modalview > .dialog > .content .badge-box {display: inline-block;}
+.modalview > .dialog > .content .badge-box  > .badge {
+  background: no-repeat top;
+  background-size: 3rem;
+  display: inline-block;
+  height: 3rem;
+  width: 3rem;
+  overflow: hidden;
+  vertical-align: middle;
+  text-indent: 99rem;
+  white-space: nowrap;
+  margin: 0 -.5rem 0 .5rem;
+}
+.modalview > .dialog > .content .badge-box > .badge.warning {
+  background-image: url(/images/warning.svg);
+  background-size:2.5rem;
+}
+.modalview > .dialog > .content .badge-box  > .badge.warning.inactive{
+  mix-blend-mode:luminosity;
+  opacity:.5
+}
 .row.flex {display:flex}
 
 h1.title .v {color:#999; font-size:1rem; font-weight:200; margin:0 0 0 .5rem; position:relative; top:.25rem; vertical-align:top}

--- a/public/images/warning.svg
+++ b/public/images/warning.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="182px" height="182px" viewBox="0 0 182 182" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 17</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <polygon id="path-1" points="83 0 166 166 0 166"></polygon>
+        <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-8" y="-8" width="182" height="182">
+            <rect x="-8" y="-8" width="182" height="182" fill="white"></rect>
+            <use xlink:href="#path-1" fill="black"></use>
+        </mask>
+    </defs>
+    <g id="CD-Anayltics" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Why-slow-related" transform="translate(-1184.000000, -62.000000)">
+            <g id="Group-17" transform="translate(1192.000000, 70.000000)">
+                <g id="Triangle-4">
+                    <use fill-opacity="0.288071784" fill="#F8E81C" fill-rule="evenodd" xlink:href="#path-1"></use>
+                    <use stroke="#E79713" mask="url(#mask-2)" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" xlink:href="#path-1"></use>
+                </g>
+                <text id="!" font-family="Lato-Black, Lato" font-size="122" font-weight="700" fill="#E79713">
+                    <tspan x="65" y="143">!</tspan>
+                </text>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
My attempt at showing security warnings. I don't like how big the modal is. I am not sure if the size can be changed. I'll have to ask Thorsten.

These show active security warnings, meaning ones that affect the current version. Clicking on the yellow triangle shows the modal.
<img width="1161" alt="screen shot 2017-03-06 at 10 04 00 pm" src="https://cloud.githubusercontent.com/assets/976479/23640355/0f97f864-02bb-11e7-8cac-178dfbb94c6b.png">
<img width="1345" alt="screen shot 2017-03-06 at 10 04 07 pm" src="https://cloud.githubusercontent.com/assets/976479/23640357/10f31586-02bb-11e7-8c2c-8b4a37578951.png">

For any previous security warnings no longer applicable to the current version of the plugin will appear in the side bar.
<img width="972" alt="screen shot 2017-03-07 at 8 54 36 am" src="https://cloud.githubusercontent.com/assets/976479/23659428/19d8e41a-0314-11e7-9000-ea6304f55e97.png">

