### PR TITLE
[FIX WEBSITE-277] - Multiple versions per warning

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -195,7 +195,7 @@ class PluginDetail extends React.PureComponent {
                         {warning.versions.map(version => {
                           return (
                             <li>
-                              {this.getReadableVersion(version)}
+                              {this.getReadableVersion(version, true)}
                             </li>
                           )
                         })}
@@ -231,7 +231,7 @@ class PluginDetail extends React.PureComponent {
                   {warning.versions.map(version => {
                     return (
                       <li>
-                        {this.getReadableVersion(version)}
+                        {this.getReadableVersion(version, false)}
                       </li>
                     )
                   })}
@@ -244,15 +244,15 @@ class PluginDetail extends React.PureComponent {
     )
   }
 
-  getReadableVersion(version) {
+  getReadableVersion(version, active) {
     if (version.firstVersion && version.lastVersion) {
       return `Affects version ${version.firstVersion} to ${version.lastVersion}`;
-    } else if (version.firstVersion) {
+    } else if (version.firstVersion && active) {
       return `Affects version ${version.lastVersion} and later`;
     } else if (version.lastVersion) {
       return `Affects version ${version.lastVersion} and earlier`;
     } else {
-      return null;
+      return active ? "Affects all versions" : "Affects some versions";
     }
   }
 


### PR DESCRIPTION
Accurately show each version per warning that it affects.

The correctly reflects pipline-maven
<img width="1336" alt="screen shot 2017-03-08 at 8 32 18 am" src="https://cloud.githubusercontent.com/assets/976479/23706329/c0fafd60-03db-11e7-9408-9e1539b81e70.png">

If pipeline-maven were active this is how it would look
<img width="1185" alt="screen shot 2017-03-08 at 8 33 35 am" src="https://cloud.githubusercontent.com/assets/976479/23706333/c2094cd4-03db-11e7-8f2f-a1bb318aa383.png">

Dependent on [the companion API PR](https://github.com/jenkins-infra/plugin-site-api/pull/30)
