### PR TITLE
[FIX WEBSITE-341] - Make presentation of new plugins nicer

### DIFF
--- a/app/components/LineChart.jsx
+++ b/app/components/LineChart.jsx
@@ -92,26 +92,22 @@ export default class LineChart extends React.PureComponent {
     installations: PropTypes.arrayOf(PropTypes.shape({
       timestamp: PropTypes.number,
       total: PropTypes.number
-    })).isRequired
+    }))
   };
 
   render() {
     const { installations, total } = this.props;
+    if (!installations) {
+      return null;
+    }
     const labels = [];
     const data = [];
     const height = calculateHeight(total);
-    if (installations) {
-      installations.sort((a,b) => {
-        a = a.timestamp;
-        b = b.timestamp;
-        return a < b ? -1 : (a > b ? 1 : 0);
-      });
-      const length = installations.length;
-      installations.slice(length - 12, length).forEach((installation) => {
-        labels.push(moment.utc(installation.timestamp).format('MMM'));
-        data.push(installation.total);
-      });
-    }
+    const length = installations.length;
+    installations.slice(length - 12, length).forEach((installation) => {
+      labels.push(moment.utc(installation.timestamp).format('MMM'));
+      data.push(installation.total);
+    });
     const lineData = chartData(labels, data);
     return (
       <div style={styles.graphContainer}>

--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -256,6 +256,10 @@ class PluginDetail extends React.PureComponent {
     }
   }
 
+  getReadableInstalls(currentInstalls) {
+    return currentInstalls != 0 ? currentInstalls : "No usage data available";
+  }
+
   render() {
     const { isFetchingPlugin, plugin } = this.props;
     if (plugin === null) {
@@ -285,7 +289,7 @@ class PluginDetail extends React.PureComponent {
                   </h1>
                   <div className="row flex">
                     <div className="col-md-4">
-                      {plugin.stats &&  <div>Installs: {plugin.stats.currentInstalls}</div>}
+                      {plugin.stats &&  <div>Installs: {this.getReadableInstalls(plugin.stats.currentInstalls)}</div>}
                       {this.getLastReleased(plugin)}
                     </div>
                     <div className="col-md-4 maintainers">

--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -68,7 +68,7 @@ class PluginDetail extends React.PureComponent {
         installations: PropTypes.arrayOf(PropTypes.shape({
           timestamp: PropTypes.number,
           total: PropTypes.number
-        })).isRequired
+        }))
       }).isRequired,
       title: PropTypes.string.isRequired,
       wiki: PropTypes.shape({


### PR DESCRIPTION
- Hide graph if no usage data available
- Show readable installation count if no usage data available

<img width="1310" alt="screen shot 2017-03-23 at 8 13 17 am" src="https://cloud.githubusercontent.com/assets/976479/24247179/0ccb5c96-0fa1-11e7-89ce-cfe861305d9d.png">

Fullscreen shot without the graph
<img width="1826" alt="screen shot 2017-03-23 at 9 20 41 am" src="https://cloud.githubusercontent.com/assets/976479/24249549/0e1a7d12-0faa-11e7-9dcb-d0fab5ae5434.png">
