### PR TITLE
[FIX WEBSITE-374] - Use batch.css

### DIFF
--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -4,3 +4,4 @@
 <link href="/assets/css/bootstrap-4.0.0-alpha.2.css" rel="stylesheet" type="text/css">
 <link href="/assets/css/base.css" rel="stylesheet" type="text/css">
 <link href="/assets/css/font-icons.css" rel="stylesheet" type="text/css">
+<link type="text/css" rel="stylesheet" href="https://wiki.jenkins.io/s/f68dfafb2b4588f7b31742327b4469ae-CDN/en_GB/6441/82994790ee2f720a5ec8daf4850ac5b7b34d2194/be65c4ed0984ca532b26983f5fc1813e/_/download/contextbatch/css/_super/batch.css?atlassian.aui.raphael.disabled=true" data-wrm-key="_super" data-wrm-batch-type="context" media="all">


### PR DESCRIPTION
This makes confluence tables look just like they do on the Jenkins wiki.
