### PR TITLE
Remove engine restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "clean": "rimraf dist",
     "postinstall": "node postinstall.js"
   },
-  "engines": {
-    "node": "~6.9.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jenkins-infra/plugin-site.git"


### PR DESCRIPTION
Attempt to fix CI builds of the `plugin-site-api`.

According to @rtyler, engine restrictions are unusual, so rip this out.