### PR TITLE
[WEBSITE-378] Show link to wiki page for jenkins.io URLs

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -163,7 +163,7 @@ class PluginDetail extends React.PureComponent {
   }
 
   showWikiUrl(url) {
-    return url && url.startsWith("https://wiki.jenkins-ci.org");
+    return url && (url.startsWith("https://wiki.jenkins-ci.org") || url.startsWith("https://wiki.jenkins.io"));
   }
 
   showWarnings = () => {


### PR DESCRIPTION
Right now the link in the sidebar is only shown when the plugin specifies a (legacy) wiki.jenkins-ci.org URL, not a wiki.jenkins.io URL.