### PR TITLE
Require docker&&linux in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('docker') {
+node('docker&&linux') {
 
   stage('Checkout') {
     checkout scm


### PR DESCRIPTION
Summary of this pull request: 

We should have Windows docker agents available soon, so make sure this only runs on Linux based docker agents.

