### PR TITLE
[WEBSITE-638] - Add a links pane with GitHub and Javadoc links

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -360,6 +360,11 @@ class PluginDetail extends React.PureComponent {
                     installations={plugin.stats.installations}
                   />
                 </div>
+                
+                <h5>Links</h5>
+                {plugin.scm && plugin.scm.link && <div><a href={plugin.scm.link}>GitHub</a></div>}
+                <div><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
+                
                 <h5>Labels</h5>
                 {this.getLabels(plugin.labels)}
                 {this.showWikiUrl(plugin.wiki.url) &&


### PR DESCRIPTION
Solves https://issues.jenkins-ci.org/browse/WEBSITE-638

Summary of this pull request: Add a new pane with links to GitHub and Javadoc. Later we can extend the list by changelog URLs once https://issues.jenkins-ci.org/browse/INFRA-2225 is ready

![image](https://user-images.githubusercontent.com/3000480/64132753-3eaf1a80-cdd2-11e9-8c32-28e0cb32b248.png)

 
CC @jenkins-infra/docs @AbhyudayaSharma