### PR TITLE
Use ≥ rather than v. notation in plugin version requirements

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -123,7 +123,7 @@ class PluginDetail extends React.PureComponent {
       }
       return (
         <div key={dependency.name} className={kind}>
-          <Link to={`/${dependency.name}`}>{dependency.title} v.{dependency.version} <span className="req">({kind})</span></Link>
+          <Link to={`/${dependency.name}`}>{dependency.title} ≥ {dependency.version} <span className="req">({kind})</span></Link>
         </div>
       );
     });


### PR DESCRIPTION
For example

> Pipeline: API v.2.36

⇒

> Pipeline: API ≥ 2.36

I think looks better, and emphasizes that later versions are accepted as well.