### PR TITLE
Remove red `(required)` from mandatory dependencies

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -123,7 +123,7 @@ class PluginDetail extends React.PureComponent {
       }
       return (
         <div key={dependency.name} className={kind}>
-          <Link to={`/${dependency.name}`}>{dependency.title} v.{dependency.version} <span className="req">({kind})</span></Link>
+          <Link to={`/${dependency.name}`}>{dependency.title} v.{dependency.version} {kind === 'required' ? '' : <span className="req">({kind})</span>}</Link>
         </div>
       );
     });

--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -70,9 +70,6 @@ body .showResults.item-finder .filters .Cols3 {column-count:1; -moz-column-count
     opacity: .67;
 }
 
-.dependencies .required .req{
-    color:#900;
-}
 .empty {opacity:.33}
 
 


### PR DESCRIPTION
It is the default, and most common, scenario for a plugin-to-plugin dependency to be required. There is no reason to highlight this in red as if it were an error the user must pay attention to. In fact we should not even be displaying **(required)** at all; it is just visual noise.