### PR TITLE
[WEBSITE-673] - Reference Plugin Wiki Migration guidelines from the plugin site + [WEBSITE-647] - Add an "Improve this page" panel for plugin documentation hosted on GitHub

### DIFF
--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -174,6 +174,10 @@ class PluginDetail extends React.PureComponent {
     return url && (url.startsWith("https://wiki.jenkins-ci.org") || url.startsWith("https://wiki.jenkins.io"));
   }
 
+  showGitHubUrl(url) {
+    return url && url.startsWith("https://github.com");
+  }
+
   showWarnings = () => {
     this.warningsModal.show();
   }
@@ -362,16 +366,22 @@ class PluginDetail extends React.PureComponent {
                 </div>
                 <h5>Labels</h5>
                 {this.getLabels(plugin.labels)}
-
+                <br/>
                 {this.showWikiUrl(plugin.wiki.url) &&
-                  <div className="alert-warning">
-                    <h5 className="header">Warning!</h5>
-                    <p>This content is served from the <a href={plugin.wiki.url} target="_wiki">Jenkins Wiki</a>.
-                       You may be unable to edit it, <a href="https://groups.google.com/forum/#!msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ">announcement</a>.
-                       We recommend moving the documentation to GitHub, see the <a href="https://jenkins.io/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github">migration guidelines</a>.
-                    </p>
+                  <div className="update-link">
+                    <h5>Help us to improve this page!</h5>
+                    This content is served from the <a href={plugin.wiki.url} target="_wiki">Jenkins Wiki</a> which is in the <a href="https://groups.google.com/forum/#!msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ" target="_blank">read-only state</a>.
+                    We recommend moving the plugin documentation to GitHub, see the guidelines <a href="https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/" target="_blank">here</a>.
                   </div>
                 }
+                {this.showGitHubUrl(plugin.wiki.url) &&
+                  <div className="update-link">
+                    <h5>Help us to improve this page!</h5>
+                    To propose a change submit a pull request to <a href={plugin.wiki.url} target="_blank">the plugin page</a> on GitHub.
+                    Read more about GitHub support on the plugin site in the <a href="https://jenkins.io/doc/developer/publishing/documentation/" target="_blank">Jenkins developer documentation</a>.  
+                  </div>
+                }
+      
                 {this.getInactiveWarnings(plugin.securityWarnings)}
               </div>
             </div>

--- a/app/components/PluginDetail.jsx
+++ b/app/components/PluginDetail.jsx
@@ -362,10 +362,14 @@ class PluginDetail extends React.PureComponent {
                 </div>
                 <h5>Labels</h5>
                 {this.getLabels(plugin.labels)}
+
                 {this.showWikiUrl(plugin.wiki.url) &&
-                  <div className="update-link">
-                    <h6>Are you maintaining this plugin?</h6>
-                    <p>Visit the <a href={plugin.wiki.url} target="_wiki">Jenkins Plugin Wiki</a> to edit this content.</p>
+                  <div className="alert-warning">
+                    <h5 className="header">Warning!</h5>
+                    <p>This content is served from the <a href={plugin.wiki.url} target="_wiki">Jenkins Wiki</a>.
+                       You may be unable to edit it, <a href="https://groups.google.com/forum/#!msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ">announcement</a>.
+                       We recommend moving the documentation to GitHub, see the <a href="https://jenkins.io/doc/developer/publishing/wiki-page/#migrating-from-wiki-to-github">migration guidelines</a>.
+                    </p>
                   </div>
                 }
                 {this.getInactiveWarnings(plugin.securityWarnings)}

--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -904,16 +904,3 @@ a.card:hover {
     border-bottom: 1px solid #CAD0D2;
     border-radius: 4px;
 }
-
-.alert-warning {
-  background-color: #fcf8e3;
-  border-color: #faebcc;
-  color: #8a6d3b;
-}
-.alert-warning .header {
-  margin-top: 1rem;
-  border-top-color: #f7e1b5;
-}
-.alert-warning .alert-link {
-  color: #66512c;
-}

--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -904,3 +904,16 @@ a.card:hover {
     border-bottom: 1px solid #CAD0D2;
     border-radius: 4px;
 }
+
+.alert-warning {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+}
+.alert-warning .header {
+  margin-top: 1rem;
+  border-top-color: #f7e1b5;
+}
+.alert-warning .alert-link {
+  color: #66512c;
+}


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/WEBSITE-673 . This change also uses the theme from Jenkins Core to highlight the warning

Before:

![image](https://user-images.githubusercontent.com/3000480/67210222-fea30600-f418-11e9-81fd-7568a4b512f9.png)


After, without GitHub:

![image](https://user-images.githubusercontent.com/3000480/69560462-150a2780-0fac-11ea-893c-3feb466733cf.png)

After, with GitHub:

![image](https://user-images.githubusercontent.com/3000480/69560492-20f5e980-0fac-11ea-8a58-14fdc53819d5.png)





CC @MarkEWaite @halkeye  @zbynek 
