### PR TITLE
[WEBSITE-405] - Update header file location so that the response metadata changes are applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If `REST_API_URL` is unset it defaults to https://plugins.jenkins.io/api.
 
 When using server side rendering, the application will download a header from an external location and inject itself
 into the content and replace the view/index.hbs. This is _intended_ for use in the Dockerfile production deployment.
-By default the location is https://jenkins.io/plugins/index.html. To specify a different location supply the
+By default the location is https://jenkins.io/template/index.html. To specify a different location supply the
 `HEADER_FILE` environment variable.
 
 ## Linting

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -24,7 +24,7 @@ const plugins = [
     }),
     __PRODUCTION__: release,
     __REST_API_URL__: JSON.stringify(process.env.REST_API_URL || "https://plugins.jenkins.io/api"),
-    __HEADER_FILE__: JSON.stringify(process.env.HEADER_FILE || "https://jenkins.io/plugins/index.html")
+    __HEADER_FILE__: JSON.stringify(process.env.HEADER_FILE || "https://jenkins.io/template/index.html")
   })
 ];
 


### PR DESCRIPTION
cc @oleg-nenashev @zbynek

Don't merge till this in prod: https://github.com/jenkins-infra/jenkins.io/pull/2674
