### PR TITLE
Make asciidoc admonitions more noticeable

### DIFF
--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -901,3 +901,12 @@ a.card:hover {
     border-bottom: 1px solid #CAD0D2;
     border-radius: 4px;
 }
+
+.modalview .content .main table {
+  border: 1px solid silver;  
+}
+
+.modalview .content .main td {
+  padding: 1em;
+}
+


### PR DESCRIPTION
Slightly mimics how it looks on GitHub.

Related to issue # 
Part of https://issues.jenkins-ci.org/browse/WEBSITE-690

Summary of this pull request: 

If the plugin documentation is migrated to asciidoc and admonitions is used (the note and info boxes) it doesn't stick out as it should on the plugin site.

This is what it will look like after the change:

![pluginsite_admonition_change](https://user-images.githubusercontent.com/300688/69981310-637e6f80-1532-11ea-8ff6-293818a6f187.png)


