### PR TITLE
Don't blobxfer inside a docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
   }
 
   agent {
-    label 'docker&&linux'
     docker {
       image 'node:12'
     }


### PR DESCRIPTION
Related to issue # INFRA-2414

Summary of this pull request: 
In the current state, the job upload files to Azure because it tries to call `docker` in the blobxfer script from the node image.

