### PR TITLE
Use isomorphic-fetch/polyfill so older browsers still have access to search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gatsby-plugin-sitemap": "^2.2.22",
     "gatsby-source-filesystem": "^2.1.46",
     "gatsby-transformer-sharp": "^2.3.12",
+    "isomorphic-fetch": "^2.2.1",
     "moment": "^2.24.0",
     "postcss-calc": "^7.0.1",
     "postcss-css-variables": "^0.14.0",

--- a/src/templates/search.jsx
+++ b/src/templates/search.jsx
@@ -13,7 +13,7 @@ import SearchResults from '../components/SearchResults';
 import SearchBox from '../components/SearchBox';
 import Filters from '../components/Filters';
 import ActiveFilters from '../components/ActiveFilters';
-
+import fetch from 'isomorphic-fetch';
 
 const doSearch = (data, setResults) => {
     const {categories, labels, page, query, sort} = data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,7 +7932,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=


### PR DESCRIPTION
Related to issue # Sentry's PLUGINSITE-R

Summary of this pull request:
Sentry reported "ReferenceError: 'fetch' is undefined" on ie11/windows 7"
I tried to reproduce it using saucelabs, but fetch seems to be defined there.