### PR TITLE
Pull the actual english version / pom url from wiki, not just the first one returned

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -60,11 +60,11 @@ const getPluginContent = async ({plugin, reporter}) => {
                 reporter,
                 url: `https://wiki.jenkins.io/rest/api/content?expand=body.view&title=${matches[1]}`
             }).then(async data => {
+                const result = data.results.find(result => plugin.wiki.url.includes(result._links.webui)) || data.results[0];
                 plugin.wiki.content = await getContentFromConfluencePage(
                     'https://wiki.jenkins.io/',
-                    `<body class="wiki-content">${data.results[0].body.view.value}</body>`
-                );
-                return plugin;  
+                    `<body class="wiki-content">${result.body.view.value}</body>`);
+                return plugin;
             });
         } catch (e) {
             console.error(`Error fetching wiki content for ${plugin.name}`, e);


### PR DESCRIPTION
Fixes #105

Summary of this pull request: 

The wiki api returns a list of all pages that matches the title. Which includes other language versions. Update the code to grab the one that directly matches the url we asked for (defaulting back to entry 0 when not found)

Fix should get merged upstream to plugin-site-api and wiki exporter
