### PR TITLE
Add issue tracker to plugin page

### DIFF
--- a/src/fragments.js
+++ b/src/fragments.js
@@ -7,6 +7,10 @@ export const PluginFragment = graphql`
     title
     url
     version
+    issueTracker {
+        name
+        url
+    }
     wiki {
       content
       url

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -50,6 +50,12 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                                     <PluginReadableInstalls currentInstalls={plugin.stats.currentInstalls} />
                                 </div>}
                                 {plugin.scm && plugin.scm.link && <div><a href={plugin.scm.link}>GitHub →</a></div>}
+                                {plugin.issueTracker && plugin.issueTracker.url && <div>
+                                Issue tracker: &nbsp;
+                                    <a href={plugin.issueTracker.url}>
+                                        {plugin.issueTracker.name}
+                                    </a>
+                                </div>}
                                 <PluginLastReleased plugin={plugin} />
                             </div>
                             <div className="col-md-4 maintainers">


### PR DESCRIPTION
Related to issue # 
https://groups.google.com/d/msg/jenkinsci-dev/haFTYlhp7h8/hkApal9WAgAJ

Requires:
https://github.com/jenkins-infra/plugin-site-api/pull/80
https://github.com/jenkins-infra/update-center2/pull/331

It is safe to deploy independently but I would wait till update center is merged

Summary of this pull request: 

Adds a field to the plugin information, showing where it's issue tracker is, to help users know where to report issues

GitHub:
![image](https://user-images.githubusercontent.com/21194782/73634621-807e0e80-4659-11ea-889c-0b8e81a19925.png)

JIRA:
![image](https://user-images.githubusercontent.com/21194782/73634646-94297500-4659-11ea-89ce-3c7663140c64.png)

