### PR TITLE
Force all urls to have slashes on the end of them since thats what nginx is already assuming

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,7 +29,7 @@ exports.createPages = async ({graphql, actions}) => {
 
     
     createPage({
-        path: '/ui/search',
+        path: '/ui/search/',
         component: searchPage,
         context: { }
     });
@@ -51,7 +51,7 @@ exports.createPages = async ({graphql, actions}) => {
 
         result.data.allJenkinsPlugin.edges.forEach(edge => {
             createPage({
-                path: edge.node.name.trim(),
+                path: `/${edge.node.name.trim()}/`,
                 component: pluginPage,
                 context: {
                     name: edge.node.name.trim()

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -55,7 +55,7 @@ function Footer() {
                             { data.categories.edges.map(({node: category}) => {
                                 return(
                                     <div key={`cat-box-id-${category.id}`} className="Entry-box">
-                                        <Link to={`/ui/search?categories=${category.id}`}>{category.title}</Link>
+                                        <Link to={`/ui/search/?categories=${category.id}`}>{category.title}</Link>
                                     </div>
                                 );
                             })}

--- a/src/components/Plugin.jsx
+++ b/src/components/Plugin.jsx
@@ -25,7 +25,7 @@ Maintainers.propTypes = PluginMaintainers.propTypes;
 
 function Plugin({plugin: {name, title, stats, requiredCore, labels, excerpt, maintainers}}) {
     return (
-        <Link to={`/${name}`} className="Plugin--PluginContainer">
+        <Link to={`/${name}/`} className="Plugin--PluginContainer">
             <div className="Plugin--IconContainer">
                 <Icon title={title} />
             </div>

--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -22,19 +22,19 @@ function PluginDependencies({dependencies} ) {
                 <ModalBody>
                     <div>
                         <p>
-              Features are sometimes detached (or split off) from Jenkins core and moved into a plugin.
-              Many plugins, like Subversion or JUnit, started as features of Jenkins core.
+                            Features are sometimes detached (or split off) from Jenkins core and moved into a plugin.
+                            Many plugins, like Subversion or JUnit, started as features of Jenkins core.
                         </p>
                         <p>
-              Plugins that depend on a Jenkins core version before such a plugin was detached from core may or may not actually use any of its features.
-              To ensure that plugins don&apos;t break whenever functionality they depend on is detached from Jenkins core, it is considered to have a dependency on the detached plugin if it declares a dependency on a version of Jenkins core before the split.
-              Since that dependency to the detached plugin is not explicitly specified, it is 
+                            Plugins that depend on a Jenkins core version before such a plugin was detached from core may or may not actually use any of its features.
+                            To ensure that plugins don&apos;t break whenever functionality they depend on is detached from Jenkins core, it is considered to have a dependency on the detached plugin if it declares a dependency on a version of Jenkins core before the split.
+                            Since that dependency to the detached plugin is not explicitly specified, it is 
                             {' '}
                             <em>implied</em>
-.
+                            .
                         </p>
                         <p>
-              Plugins that don&apos;t regularly update which Jenkins core version they depend on will accumulate implied dependencies over time.
+                            Plugins that don&apos;t regularly update which Jenkins core version they depend on will accumulate implied dependencies over time.
                         </p>
                     </div>
                 </ModalBody>
@@ -46,16 +46,16 @@ function PluginDependencies({dependencies} ) {
                         if (kind === 'implied') {
                             return (
                                 <div key={dependency.name} className={kind}>
-                                    <Link to={`/${dependency.name}`}>
+                                    <Link to={`/${dependency.name}/`}>
                                         {dependency.title}
                                         {' '}
-v.
+                                        v.
                                         {dependency.version} 
                                         {' '}
                                         <span className="req">
-(
+                                            (
                                             {kind}
-)
+                                            )
                                         </span>
                                     </Link>
                                     <a href="#" onClick={toggleShowImplied}><span className="req">(what&apos;s this?)</span></a>
@@ -64,17 +64,17 @@ v.
                         }
                         return (
                             <div key={dependency.name} className={kind}>
-                                <Link to={`/${dependency.name}`}>
+                                <Link to={`/${dependency.name}/`}>
                                     {dependency.title}
                                     {' '}
-≥ 
+                                    ≥ 
                                     {' '}
                                     {dependency.version} 
                                     {' '}
                                     {kind === 'required' ? '' : <span className="req">
-(
+                                        (
                                         {kind}
-)
+                                        )
                                     </span>}
                                 </Link>
                             </div>

--- a/src/components/PluginLabels.jsx
+++ b/src/components/PluginLabels.jsx
@@ -26,7 +26,7 @@ function PluginLabels({labels}) {
         const text = (allLabels[id] || id).replace(' development', '');
         return (
             <div className="label-link" key={id}>
-                <Link to={`/ui/search?labels=${id}`}>{text}</Link>
+                <Link to={`/ui/search/?labels=${id}`}>{text}</Link>
             </div>
         );
     });

--- a/src/components/PluginLink.jsx
+++ b/src/components/PluginLink.jsx
@@ -9,7 +9,7 @@ import {cleanTitle} from '../commons/helper';
 export default function PluginLink({title = '', name = ''}) {
     return (
         <div className={classNames(styles.Item, 'Entry-box')}>
-            <Link key={name} to={`/${name}`} className="titleOnly">
+            <Link key={name} to={`/${name}/`} className="titleOnly">
                 {cleanTitle(title)}
             </Link>
         </div>


### PR DESCRIPTION
If you goto https://plugins.jenkins.io/saml, nginx will rewrite to https://plugins.jenkins.io/saml/, then javascript will rewrite to https://plugins.jenkins.io/saml
On top of that, if you click on the various dependancies link, it replaces the url, instead of pushes, so the back button doesn't work right.

Its related to https://github.com/gatsbyjs/gatsby/issues/8357

