### PR TITLE
Add warning boxes for plugins which are deprecated or up for adoption

### DIFF
--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -30,7 +30,7 @@ function PluginGovernanceStatus({plugin}) {
                             <td className="badge-box"><span className="badge active warning"/></td>
                             <td className="alert-text">
                                 <b>Deprecated:</b>
-                                {' The following plugins have been marked as deprecated. '}
+                                {'This plugin has been marked as deprecated. '}
                                 {'In general this means that the plugin is obsolete, no longer being developed, or may no longer work. '}
                                 {'See the plugin\'s documentation for further information about the cause for the deprecation, and suggestions on how to proceed.'}
                             </td>

--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -8,11 +8,11 @@ function PluginGovernanceStatus({plugin}) {
     return plugin.labels.map((id) => {
         if (id === 'adopt-this-plugin') {
             return (
-                <div className="alert">
+                <div className="plugin-governance-notice">
                     <table>
                         <tr>
                             <td className="badge-box"><span className="badge active warning"/></td>
-                            <td className="alert-text">
+                            <td className="plugin-governance-notice-text">
                                 <b>This plugin is up for adoption!</b>
                                 {' We are looking for new maintainers. Visit our '}
                                 <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/">Adopt a Plugin</a>
@@ -24,11 +24,11 @@ function PluginGovernanceStatus({plugin}) {
             );
         } else if (id === 'deprecated') {
             return (
-                <div className="alert">
+                <div className="plugin-governance-notice">
                     <table>
                         <tr>
                             <td className="badge-box"><span className="badge active warning"/></td>
-                            <td className="alert-text">
+                            <td className="plugin-governance-notice-text">
                                 <b>Deprecated:</b>
                                 {'This plugin has been marked as deprecated. '}
                                 {'In general this means that the plugin is obsolete, no longer being developed, or may no longer work. '}

--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -6,7 +6,7 @@ function PluginGovernanceStatus({plugin}) {
         return null;
     }
     return plugin.labels.map((id) => {
-        if (id === 'adopt-this-plugin' || id === 'adopt-me') {
+        if (id === 'adopt-this-plugin') {
             return (
                 <div className="alert">
                     <table>
@@ -32,7 +32,11 @@ function PluginGovernanceStatus({plugin}) {
                                 <b>Deprecated:</b>
                                 {'This plugin has been marked as deprecated. '}
                                 {'In general this means that the plugin is obsolete, no longer being developed, or may no longer work. '}
-                                {'See the plugin\'s documentation for further information about the cause for the deprecation, and suggestions on how to proceed.'}
+                                {'See the documentation for further information about the cause for the deprecation, and suggestions on how to proceed. '}
+                                {'The deprecation process is also documented '}
+                                <a href="https://jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin">here</a>
+                                {'.'}
+
                             </td>
                         </tr>
                     </table>

--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -14,9 +14,9 @@ function PluginGovernanceStatus({plugin}) {
                             <td className="badge-box"><span className="badge active warning"/></td>
                             <td className="alert-text">
                                 <b>This plugin is up for adoption!</b>
-                                {' We are looking for new maintainers. See '}
-                                <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/">this page</a>
-                                {' for more information.'}
+                                {' We are looking for new maintainers. Visit our '}
+                                <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/">Adopt a Plugin</a>
+                                {' initiative for more information.'}
                             </td>
                         </tr>
                     </table>

--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -31,7 +31,7 @@ function PluginGovernanceStatus({plugin}) {
                             <td className="plugin-governance-notice-text">
                                 <b>Deprecated:</b>
                                 {'This plugin has been marked as deprecated. '}
-                                {'In general this means that the plugin is obsolete, no longer being developed, or may no longer work. '}
+                                {'In general, this means that this plugin is either obsolete, no longer being developed, or may no longer work. '}
                                 {'See the documentation for further information about the cause for the deprecation, and suggestions on how to proceed. '}
                                 {'The deprecation process is also documented '}
                                 <a href="https://jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin">here</a>

--- a/src/components/PluginGovernanceStatus.jsx
+++ b/src/components/PluginGovernanceStatus.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function PluginGovernanceStatus({plugin}) {
+    if (!plugin || !plugin.labels) {
+        return null;
+    }
+    return plugin.labels.map((id) => {
+        if (id === 'adopt-this-plugin' || id === 'adopt-me') {
+            return (
+                <div className="alert">
+                    <table>
+                        <tr>
+                            <td className="badge-box"><span className="badge active warning"/></td>
+                            <td className="alert-text">
+                                <b>This plugin is up for adoption!</b>
+                                {' We are looking for new maintainers. See '}
+                                <a href="https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/">this page</a>
+                                {' for more information.'}
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            );
+        } else if (id === 'deprecated') {
+            return (
+                <div className="alert">
+                    <table>
+                        <tr>
+                            <td className="badge-box"><span className="badge active warning"/></td>
+                            <td className="alert-text">
+                                <b>Deprecated:</b>
+                                {' The following plugins have been marked as deprecated. '}
+                                {'In general this means that the plugin is obsolete, no longer being developed, or may no longer work. '}
+                                {'See the plugin\'s documentation for further information about the cause for the deprecation, and suggestions on how to proceed.'}
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            );
+        } else {
+            return null;
+        }
+            
+    });
+}
+  
+PluginGovernanceStatus.propTypes = {
+    plugin: PropTypes.shape({
+        labels: PropTypes.arrayOf(PropTypes.string).isRequired
+    })
+};
+
+export default PluginGovernanceStatus;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -873,3 +873,19 @@ a.card:hover {
 #pluginPage #grid-box .content .main td {
   padding: 1em;
 }
+
+#pluginPage .alert {
+  padding: 5px;
+  background-color: #fcf8e3;
+  color: #a48d62;
+  border-color: #faebcc;
+  margin-bottom: 5px;
+}
+
+#pluginPage .alert table {
+  margin-bottom: 0px;
+}
+
+#pluginPage .alert .alert-text {
+  padding-left: 20px;
+}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -874,7 +874,7 @@ a.card:hover {
   padding: 1em;
 }
 
-#pluginPage .alert {
+#pluginPage .plugin-governance-notice {
   padding: 5px;
   background-color: #fcf8e3;
   color: #a48d62;
@@ -882,10 +882,10 @@ a.card:hover {
   margin-bottom: 5px;
 }
 
-#pluginPage .alert table {
+#pluginPage .plugin-governance-notice table {
   margin-bottom: 0px;
 }
 
-#pluginPage .alert .alert-text {
+#pluginPage .plugin-governance-notice .plugin-governance-notice-text {
   padding-left: 20px;
 }

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -12,6 +12,7 @@ import PluginLabels from '../components/PluginLabels';
 import PluginLastReleased from '../components/PluginLastReleased';
 import PluginActiveWarnings from '../components/PluginActiveWarnings';
 import PluginInactiveWarnings from '../components/PluginInactiveWarnings';
+import PluginGovernanceStatus from '../components/PluginGovernanceStatus';
 import PluginMaintainers from '../components/PluginMaintainers';
 import PluginReadableInstalls from '../components/PluginReadableInstalls';
 
@@ -61,6 +62,9 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                                 <PluginDependencies dependencies={plugin.dependencies} />
                             </div>
                         </div>
+
+                        <PluginGovernanceStatus plugin={plugin} />
+
                         {plugin.wiki.content && <div className="content" dangerouslySetInnerHTML={{__html: plugin.wiki.content}} />}
                     </div>
                 </div>


### PR DESCRIPTION
Follow-up to the discussion in https://groups.google.com/forum/#!topic/jenkinsci-dev/UoEqG5AaWJU
. This pull request add warning boxes for plugins which have `deprecated`, `adopt-this-plugin` and `adopt-me` labels. Colors have been taken from standard Jenkins warning boxes. Sorry about my layout MADSKILLZ, feel free to rework.

Text for the deprecated plugins has been taken from https://github.com/jenkinsci/jenkins/pull/4073 by @casz. Unfortunately deprecated plugins do not always reference the documentation, the guideline is quite vague at the moment.

![image](https://user-images.githubusercontent.com/3000480/74741907-f5f2fd00-525d-11ea-802f-ff1f5438be1a.png)

![image](https://user-images.githubusercontent.com/3000480/74741954-060adc80-525e-11ea-99a2-4600184e307d.png)


 

