### PR TITLE
Try to ignore more sentry alerts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -143,8 +143,7 @@ module.exports = {
                     'should_do_lastpass_here',
                 ],
                 blacklistUrls: [
-                    '^chrome-extension:',
-                    '^moz-extension:',
+                    /^moz-extension:\//,
                     // Facebook flakiness
                     /graph\.facebook\.com/i,
                     // Facebook blocked
@@ -153,6 +152,7 @@ module.exports = {
                     /eatdifferent\.com\.woopra-ns\.com/i,
                     /static\.woopra\.com\/js\/woopra\.js/i,
                     // Chrome extensions
+                    /^chrome-extension:\//,
                     /extensions\//i,
                     /^chrome:\/\//i,
                     // Other plugins


### PR DESCRIPTION
We've been getting a bunch of sentry alerts for the site for various chrome plugins.

I'm suspicious the previous regexes didn't work right. So swapping them out.

Super hard to test without deploying.