### PR TITLE
Remove Jira table, improve side panel links

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -31,6 +31,8 @@ function getContentFromConfluencePage(url, content) {
 
     // Remove any table of contents
     $('.toc').remove();
+    // remove jira issue table
+    $('.jira-table.conf-macro.output-block').remove();
 
     // Replace href/src with the wiki url
     $('[href]').each((idx, elm) => {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -227,7 +227,7 @@ transform: scale(-1, 1);
 #pluginPage #grid-box .gutter > .btn > span {font-size:1.1rem; line-height:1.3rem; font-weight:500}
 #pluginPage #grid-box .gutter > .btn > .v {display:block; font-weight:200; font-size:.75rem; white-space:normal}
 #pluginPage #grid-box .gutter .lbl {display:inline-block; margin-right:.5rem}
-#pluginPage #grid-box .gutter .label-link{display:block;}
+##pluginPage #grid-box .gutter .label-link a{display:block; line-height: 1.5rem; padding: 4px 0;}
 #pluginPage #grid-box .gutter .chart {margin:1rem 0 2rem}
 #pluginPage #grid-box {
   margin-left: 15px;

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -83,8 +83,8 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                     </div>
                 
                     <h5>Links</h5>
-                    {plugin.scm && plugin.scm.link && <div><a href={plugin.scm.link}>GitHub</a></div>}
-                    <div><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
+                    {plugin.scm && plugin.scm.link && <div className="label-link"><a href={plugin.scm.link}>GitHub</a></div>}
+                    <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
                 
                     <h5>Labels</h5>
                     <PluginLabels labels={plugin.labels} />
@@ -96,8 +96,8 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                             <a href={plugin.wiki.url} target="_wiki">Jenkins Wiki</a>
                             {' the '}
                             <a href="https://groups.google.com/forum/#!msg/jenkinsci-dev/lNmas8aBRrI/eL3u7A6qBwAJ" rel="noopener noreferrer" target="_blank">read-only state</a>
-                            {'. We recommend moving the plugin documentation to GitHub, see the guidelines '}
-                            <a href="https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/" rel="noopener noreferrer" target="_blank">here</a>
+                            {'. We recommend moving the plugin documentation to GitHub, see '}
+                            <a href="https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/" rel="noopener noreferrer" target="_blank">the guidelines</a>
                             {'.'}
                         </div>
                     }


### PR DESCRIPTION
3 minor SEO related fixes
* remove the Jira confluence macro which doesn't work anywhere and breaks usability on mobile
* increase spacing for links in side panel (reported by Chrome audit)
* meaningful description for the guidelines link (also from Chrome audit)