### PR TITLE
Migrate gatsby configs from plugin to gatsby-browser

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,56 @@
+exports.onClientEntry = function () {
+    require.ensure(['@sentry/browser'], (require) => {
+        const Sentry = require('@sentry/browser');
+        Sentry.init({
+            dsn: 'https://495b0bd32a5e4a2287c3fe4b061ee24f@sentry.io/1882460',
+            environment: process.env.NODE_ENV,
+            enabled: ['production', 'stage'].includes(process.env.NODE_ENV),
+            // from https://docs.sentry.io/platforms/javascript/#decluttering-sentry
+            ignoreErrors: [
+                // Random plugins/extensions
+                'top.GLOBALS',
+                // See: http://blog.errorception.com/2012/03/tale-of-unfindable-js-error.html
+                'originalCreateNotification',
+                'canvas.contentDocument',
+                'MyApp_RemoveAllHighlights',
+                'http://tt.epicplay.com',
+                'Can\'t find variable: ZiteReader',
+                'jigsaw is not defined',
+                'ComboSearch is not defined',
+                'http://loading.retry.widdit.com/',
+                'atomicFindClose',
+                // Facebook borked
+                'fb_xd_fragment',
+                // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to
+                // reduce this. (thanks @acdha)
+                // See http://stackoverflow.com/questions/4113268
+                'bmi_SafeAddOnload',
+                'EBCallBackMessageReceived',
+                // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
+                'conduitPage',
+                'Cannot redefine property: BetterJsPop',
+                'should_do_lastpass_here',
+            ],
+            blacklistUrls: [
+                /^moz-extension:\//,
+                // Facebook flakiness
+                /graph\.facebook\.com/i,
+                // Facebook blocked
+                /connect\.facebook\.net\/en_US\/all\.js/i,
+                // Woopra flakiness
+                /eatdifferent\.com\.woopra-ns\.com/i,
+                /static\.woopra\.com\/js\/woopra\.js/i,
+                // Chrome extensions
+                /^chrome-extension:\//,
+                /extensions\//i,
+                /^chrome:\/\//i,
+                // Other plugins
+                /127\.0\.0\.1:4001\/isrunning/i, // Cacaoweb
+                /webappstoolbarba\.texthelp\.com\//i,
+                /metrics\.itunes\.apple\.com\.edgesuite\.net\//i
+            ]
+        });
+        window.Sentry = Sentry;
+    });
+};
+

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -109,58 +109,6 @@ module.exports = {
                 color: 'tomato',
                 showSpinner: false,
             },
-        },
-        {
-            resolve: 'gatsby-plugin-sentry',
-            options: {
-                dsn: 'https://495b0bd32a5e4a2287c3fe4b061ee24f@sentry.io/1882460',
-                environment: process.env.NODE_ENV,
-                enabled: ['production', 'stage'].includes(process.env.NODE_ENV),
-                // from https://docs.sentry.io/platforms/javascript/#decluttering-sentry
-                ignoreErrors: [
-                    // Random plugins/extensions
-                    'top.GLOBALS',
-                    // See: http://blog.errorception.com/2012/03/tale-of-unfindable-js-error.html
-                    'originalCreateNotification',
-                    'canvas.contentDocument',
-                    'MyApp_RemoveAllHighlights',
-                    'http://tt.epicplay.com',
-                    'Can\'t find variable: ZiteReader',
-                    'jigsaw is not defined',
-                    'ComboSearch is not defined',
-                    'http://loading.retry.widdit.com/',
-                    'atomicFindClose',
-                    // Facebook borked
-                    'fb_xd_fragment',
-                    // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to
-                    // reduce this. (thanks @acdha)
-                    // See http://stackoverflow.com/questions/4113268
-                    'bmi_SafeAddOnload',
-                    'EBCallBackMessageReceived',
-                    // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
-                    'conduitPage',
-                    'Cannot redefine property: BetterJsPop',
-                    'should_do_lastpass_here',
-                ],
-                blacklistUrls: [
-                    /^moz-extension:\//,
-                    // Facebook flakiness
-                    /graph\.facebook\.com/i,
-                    // Facebook blocked
-                    /connect\.facebook\.net\/en_US\/all\.js/i,
-                    // Woopra flakiness
-                    /eatdifferent\.com\.woopra-ns\.com/i,
-                    /static\.woopra\.com\/js\/woopra\.js/i,
-                    // Chrome extensions
-                    /^chrome-extension:\//,
-                    /extensions\//i,
-                    /^chrome:\/\//i,
-                    // Other plugins
-                    /127\.0\.0\.1:4001\/isrunning/i, // Cacaoweb
-                    /webappstoolbarba\.texthelp\.com\//i,
-                    /metrics\.itunes\.apple\.com\.edgesuite\.net\//i
-                ]
-            }
         }
     ]
 };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "homepage": "https://plugins.jenkins.io/",
   "dependencies": {
     "@babel/core": "^7.9.0",
+    "@sentry/browser": "^5.17.0",
     "chart.js": "^2.9.3",
     "cheerio": "^1.0.0-rc.3",
     "classnames": "^2.2.6",
@@ -68,7 +69,6 @@
     "gatsby-plugin-postcss": "^2.2.3",
     "gatsby-plugin-react-helmet": "^3.2.4",
     "gatsby-plugin-robots-txt": "^1.5.0",
-    "gatsby-plugin-sentry": "^1.0.1",
     "gatsby-plugin-sharp": "^2.6.3",
     "gatsby-plugin-sitemap": "^2.3.4",
     "gatsby-source-filesystem": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,56 +1975,56 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@latest":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.12.1.tgz#dc1f268595269fb7277f55eb625c7e92d76dc01b"
-  integrity sha512-Zl7VdppUxctyaoqMSEhnDJp2rrupx8n8N2n3PSooH74yhB2Z91nt84mouczprBsw3JU1iggGyUw9seRFzDI1hw==
+"@sentry/browser@^5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.17.0.tgz#0c3796cb02df3ec8db13341564fae0bc83e148c5"
+  integrity sha512-++pXpCHtdek1cRUwVeLvlxUJ2w1s+eiC9qN1N+7+HdAjHpBz2/tA1sKBCqwwVQZ490Cf2GLll9Ao7fuPPmveRQ==
   dependencies:
-    "@sentry/core" "5.12.0"
-    "@sentry/types" "5.12.0"
-    "@sentry/utils" "5.12.0"
+    "@sentry/core" "5.17.0"
+    "@sentry/types" "5.17.0"
+    "@sentry/utils" "5.17.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.12.0.tgz#d6380c4ef7beee5f418ac1d0e5be86a2de2af449"
-  integrity sha512-wY4rsoX71QsGpcs9tF+OxKgDPKzIFMRvFiSRcJoPMfhFsTilQ/CBMn/c3bDtWQd9Bnr/ReQIL6NbnIjUsPHA4Q==
+"@sentry/core@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.17.0.tgz#b2deef95465c766076d5cffd8534a67100f9b821"
+  integrity sha512-Kfx4rGKDC7V1YJjTGJXyl12VVHxM8Cjpu61YOyF8kXoXXg9u06C3n0G1dmfzLQERKXasUVMtXRBdKx/OjYpl1g==
   dependencies:
-    "@sentry/hub" "5.12.0"
-    "@sentry/minimal" "5.12.0"
-    "@sentry/types" "5.12.0"
-    "@sentry/utils" "5.12.0"
+    "@sentry/hub" "5.17.0"
+    "@sentry/minimal" "5.17.0"
+    "@sentry/types" "5.17.0"
+    "@sentry/utils" "5.17.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.12.0.tgz#5e8c8f249f5bdbeb8cc4ec02c2ccc53a67f2cc02"
-  integrity sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==
+"@sentry/hub@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.17.0.tgz#b7d255ca3f766385911d9414af97f388e869d996"
+  integrity sha512-lyUbEmshwaMYdAzy4iwgizgvKODVVloB2trnefpq90AuWCdvzcxMLIGULx1ou+KohccqdNorYICKWeuRscKq5A==
   dependencies:
-    "@sentry/types" "5.12.0"
-    "@sentry/utils" "5.12.0"
+    "@sentry/types" "5.17.0"
+    "@sentry/utils" "5.17.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.12.0.tgz#2611e2aa520c1edb7999e6de51bd65ec66341757"
-  integrity sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==
+"@sentry/minimal@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.17.0.tgz#b40e4b4109b098840277def3b51cc20ae6767164"
+  integrity sha512-v8xfkySXKrliZO6er6evlVe/ViUcqN0O8BhGyauK28Mf+KnKEOs5W6oWbt4qCDIttw9ynKIYyRrkAl/9oUR76A==
   dependencies:
-    "@sentry/hub" "5.12.0"
-    "@sentry/types" "5.12.0"
+    "@sentry/hub" "5.17.0"
+    "@sentry/types" "5.17.0"
     tslib "^1.9.3"
 
-"@sentry/types@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.12.0.tgz#5367e53c74261beea01502e3f7b6f3d822682a31"
-  integrity sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg==
+"@sentry/types@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.17.0.tgz#b8d245ac7d5caa749c549e9f72aab2d6522afe63"
+  integrity sha512-1z8EXzvg8GcsBNnSXgB5/G7mz2PwmMt9mjOrVG1jhtSGH1c7WvB32F5boqoMcjIJmy5MrBGaaXwrF/RRJrwUQg==
 
-"@sentry/utils@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.12.0.tgz#62967f934a3ee6d21472eac0219084e37225933e"
-  integrity sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==
+"@sentry/utils@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.17.0.tgz#b809b067665f3ebaea77ba7b5d1d1d14a4ed76cb"
+  integrity sha512-qn8WgZcSkV/rx0ezp9q/xFjP7aMaYZO1/JYLXV4o6pYrQ9tvMmmwAZT39FpJunhhbkR36WNEuRB9C2K250cb/A==
   dependencies:
-    "@sentry/types" "5.12.0"
+    "@sentry/types" "5.17.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
@@ -7086,13 +7086,6 @@ gatsby-plugin-robots-txt@^1.5.0:
   dependencies:
     "@babel/runtime" "^7.5.1"
     generate-robotstxt "^7.1.0"
-
-gatsby-plugin-sentry@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sentry/-/gatsby-plugin-sentry-1.0.1.tgz#d146e3851488c9545f2c0689cad62bf6e7d1c653"
-  integrity sha512-rKIngbFbBwwGYJi1ayUtEz34tXxpLXvSMD3WWVmdtXs0wrYrlGs30nFJ4JJIxcA7fWtx3hQ2yd5O2ZyQ832G2g==
-  dependencies:
-    "@sentry/browser" latest
 
 gatsby-plugin-sharp@^2.6.3:
   version "2.6.3"


### PR DESCRIPTION
Gatsby json stringify's the config items so they can be sent to the
front end for the "browser on client entry" event. Regexs can't be
serliazed into json.

I decided it wasn't worth fighting and fixing it, since its easy enough
just to move the couple lines into gatsby-browser.js with everything