### PR TITLE
fix url generated for "report a problem" #254

### DIFF
--- a/src/components/ReportAProblem.jsx
+++ b/src/components/ReportAProblem.jsx
@@ -6,7 +6,7 @@ function ReportAProblem({reportProblemTitle, reportProblemUrl, reportProblemRela
     
     return (
         <p className="box">
-            <a href={`https://github.com/jenkins-infra/plugin-site/issues/new?labels=bug&template=4-bug.md&title=${reportProblemTitle} page - TODO: Put a summary here&body=Problem with the [${reportProblemTitle}](https://plugins.jenkins.io${reportProblemUrl}) page, [source file](https://github.com/jenkins-infra/plugin-site/tree/master/src${reportProblemRelativeSourcePath})%0A%0ATODO: Describe the expected and actual behavior here %0A%0A%23%23 Screenshots %0A%0A TODO: Add screenshots if possible %0A%0A%23%23 Possible Solution %0A%0A%3C!-- If you have suggestions on a fix for the bug, please describe it here. --%3E %0A%0AN/A`} title={title}>
+            <a href={`https://github.com/jenkins-infra/plugin-site/issues/new?labels=bug&template=4-bug.md&title=${reportProblemTitle} page - TODO: Put a summary here&body=Problem with the [${reportProblemTitle}](https://plugins.jenkins.io${reportProblemUrl}) page, [source file](https://github.com/jenkins-infra/plugin-site/tree/master/src/${reportProblemRelativeSourcePath})%0A%0ATODO: Describe the expected and actual behavior here %0A%0A%23%23 Screenshots %0A%0A TODO: Add screenshots if possible %0A%0A%23%23 Possible Solution %0A%0A%3C!-- If you have suggestions on a fix for the bug, please describe it here. --%3E %0A%0AN/A`} title={title}>
                 Report a problem
             </a>
         </p>


### PR DESCRIPTION
Related to issue Fixes #254

Summary of this pull request: Added the missing slash for the link created from the "Report a problem" in the footer here https://plugins.jenkins.io/active-directory/


