### PR TITLE
Moved the plugin name above all the tabs and made it common for all tabs

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -257,8 +257,9 @@ transform: scale(-1, 1);
 }
 .row.flex {display:flex}
 
-h1.title-details .sub {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
-h1.title-details .version {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
+div.title-details .sub {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
+div.title-details .version {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
+
 .markdown-body .anchor {display:none}
 .markdown-body h1 {font-size:2rem; margin:4rem 0 1rem;}
 .markdown-body h2 {font-size:1.5rem; margin-top:2rem;}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -257,8 +257,8 @@ transform: scale(-1, 1);
 }
 .row.flex {display:flex}
 
-h1.title .v {color:#999; font-size:1rem; font-weight:200; margin:0 0 0 .5rem; position:relative; top:.25rem; vertical-align:top}
-h1.title .sub {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
+h1.title-details .sub {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
+h1.title-details .version {display:block; font-weight:normal; font-size:.85rem; color:#999; margin-top:.25rem}
 .markdown-body .anchor {display:none}
 .markdown-body h1 {font-size:2rem; margin:4rem 0 1rem;}
 .markdown-body h2 {font-size:1.5rem; margin-top:2rem;}

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -51,6 +51,9 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
 
             <div className="row flex">
                 <div className="col-md-9 main">
+                    <h1 className="title">
+                        {cleanTitle(plugin.title)}
+                    </h1>
                     <ul className="nav nav-tabs">
                         {tabs.map(tab => (
                             <li className="nav-item" key={tab.id}>
@@ -60,10 +63,12 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                     </ul>
                     <div className="padded">
                         {state.selectedTab === 'documentation' && (<>
-                            <h1 className="title">
-                                {cleanTitle(plugin.title)}
+                            <h1 className="title-details">
                                 <PluginActiveWarnings securityWarnings={plugin.securityWarnings} />
-                                <span className="v">{plugin.version}</span>
+                                <span className="version">
+                                    {'Version: '}
+                                    {plugin.version}
+                                </span>
                                 <span className="sub">
                                     {'Minimum Jenkins requirement: '}
                                     {plugin.requiredCore}

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -63,7 +63,7 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                     </ul>
                     <div className="padded">
                         {state.selectedTab === 'documentation' && (<>
-                            <h1 className="title-details">
+                            <div className="title-details">
                                 <PluginActiveWarnings securityWarnings={plugin.securityWarnings} />
                                 <span className="version">
                                     {'Version: '}
@@ -77,7 +77,7 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                                     {'ID: '}
                                     {plugin.name}
                                 </span>
-                            </h1>
+                            </div>
                             <div className="row flex">
                                 <div className="col-md-4">
                                     {plugin.stats && <div>


### PR DESCRIPTION
Related to issue https://github.com/jenkins-infra/plugin-site/issues/306 

Summary of this pull request: Moved the plugin name above all tabs and made it common for all tabs and also made version in a separate row.
![image](https://user-images.githubusercontent.com/19318218/93671593-e4a6f300-fac1-11ea-8e81-8bc4dd96a2a6.png)

@oleg-nenashev Please review this PR


