### PR TITLE
Show dependent pulgins in dependencies tab

### DIFF
--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -29,7 +29,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
     };
     const reverseDependencyLink = (dependency) => {
         return (
-            <div key={`${dependency.node.id}-revese`}>
+             <div key={dependency.node.id`}>
                 <Link to={`/${dependency.node.id}/`}>
                     {dependency.node.title}
                 </Link>

--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Link} from 'gatsby';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 
-function PluginDependencies({dependencies} ) {
+function PluginDependencies({dependencies, reverseDependencies} ) {
     const [isShowImplied, setShowImplied] = React.useState(false);
     const toggleShowImplied = (e) => {
         e && e.preventDefault();
@@ -23,6 +23,15 @@ function PluginDependencies({dependencies} ) {
                     {dependency.title}
                     {' ≥ '}
                     {dependency.version}
+                </Link>
+            </div>
+        );
+    };
+    const reverseDependencyLink = (dependency) => {
+        return (
+            <div key={`${dependency.node.id}-revese`}>
+                <Link to={`/${dependency.node.id}/`}>
+                    {dependency.node.title}
                 </Link>
             </div>
         );
@@ -55,7 +64,7 @@ function PluginDependencies({dependencies} ) {
             <div id="pluginDependencies">
                 {
                     !(optionalDependencies.length + impliedDependencies.length) ? '' : (
-                        <h2>Required</h2>
+                        <h3>Required</h3>
                     )
                 }
                 {
@@ -63,7 +72,7 @@ function PluginDependencies({dependencies} ) {
                 }
                 {
                     !optionalDependencies.length ? '' : (
-                        <h2>Optional</h2>
+                        <h3>Optional</h3>
                     )
                 }
                 {
@@ -71,15 +80,23 @@ function PluginDependencies({dependencies} ) {
                 }
                 {
                     !impliedDependencies.length ? '' : (
-                        <h2>
+                        <h3>
                             Implied
                             {' '}
                             <a href="#" onClick={toggleShowImplied}><span className="req">(what&apos;s this?)</span></a>
-                        </h2>
+                        </h3>
                     )
                 }
                 {
                     impliedDependencies.map(dependencyLink)
+                }
+                {
+                    !reverseDependencies.length ? '' : (
+                        <h2>Dependent plugins</h2>
+                    )
+                }
+                {
+                    reverseDependencies.map(reverseDependencyLink)
                 }
             </div>
         </>
@@ -94,6 +111,14 @@ PluginDependencies.propTypes = {
             version: PropTypes.string.isRequired,
             optional: PropTypes.bool,
             implied: PropTypes.bool
+        })
+    ),
+    reverseDependencies: PropTypes.arrayOf(
+        PropTypes.shape({
+            node: PropTypes.shape({
+                id: PropTypes.string.isRequired,
+                title: PropTypes.string.isRequired,
+            })
         })
     )
 };

--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -38,7 +38,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
     };
     return (
         <>
-            <h1>Dependencies</h1>
+            <h2>Dependencies</h2>
             <Modal placement="bottom" isOpen={isShowImplied} target="pluginDependencies" toggle={toggleShowImplied}>
                 <ModalHeader toggle={toggleShowImplied}>About Implied Plugin Dependencies</ModalHeader >
                 <ModalBody>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -46,8 +46,12 @@ body .showResults #plugin-search-form:before {display:none}
 }
 .isFiltered .filters .show-all {display: inline-block}
 
-#pluginDependencies h2{
+#pluginDependencies h3{
     font-size: 1.2rem;
+    margin-top: .7rem;
+}
+
+#pluginDependencies h2{
     margin-top: .7rem;
 }
 

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -41,7 +41,7 @@ function getDefaultTab() {
     return tabs[0].id;
 }
 
-function PluginPage({data: {jenkinsPlugin: plugin}}) {
+function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseDependencies}}) {
     const [state, setState] = useState({selectedTab: getDefaultTab()});
     const pluginPage = 'templates/plugin.jsx';
 
@@ -99,7 +99,7 @@ function PluginPage({data: {jenkinsPlugin: plugin}}) {
                         </>)}
                         {state.selectedTab === 'releases' && <PluginReleases pluginId={plugin.id} />}
                         {state.selectedTab === 'issues' && <PluginIssues pluginId={plugin.id} />}
-                        {state.selectedTab === 'dependencies' && <PluginDependencies dependencies={plugin.dependencies} />}
+                        {state.selectedTab === 'dependencies' && <PluginDependencies dependencies={plugin.dependencies} reverseDependencies={reverseDependencies.edges}/>}
                     </div>
                 </div>
                 <div className="col-md-3 gutter">
@@ -203,7 +203,15 @@ PluginPage.propTypes = {
                 url: PropTypes.string
             }).isRequired,
             version: PropTypes.string
-        }).isRequired
+        }).isRequired,
+        reverseDependencies: PropTypes.arrayOf(
+            PropTypes.shape({
+                node: PropTypes.shape({
+                    id: PropTypes.string.isRequired,
+                    title: PropTypes.string.isRequired,
+                })
+            })
+        )
     }).isRequired
 };
 
@@ -212,6 +220,26 @@ export const pageQuery = graphql`
   query PluginBySlug($name: String!) {
     jenkinsPlugin(name: {eq: $name}) {
       ...JenkinsPluginFragment
+    }
+
+    reverseDependencies: allJenkinsPlugin(
+      filter: {
+        dependencies: {
+          elemMatch: {
+            name: {eq: $name}
+          }
+        }
+      }
+      sort: {
+        fields: [title]
+        order: ASC
+      }) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
Summary of this pull request: show dependent plugins (reverse dependencies) in the dependencies tab.
This is a part of my Hacktoberfest contribution.

![image](https://user-images.githubusercontent.com/1105305/95020377-0cbe5680-066b-11eb-852b-e505579dc3f8.png)


