### PR TITLE
Replace react-time-ago with react-timeago

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-chartjs-2": "^2.9.0",
     "react-helmet": "^6.1.0",
     "react-radio-group": "^3.0.3",
-    "react-time-ago": "^5.0.8",
+    "react-timeago": "^5.2.0",
     "reactstrap": "^8.4.1"
   },
   "devDependencies": {

--- a/src/commons/helper.js
+++ b/src/commons/helper.js
@@ -1,3 +1,11 @@
+import enStrings from 'react-timeago/lib/language-strings/en';
+import buildFormatter from 'react-timeago/lib/formatters/buildFormatter';
+
+export const formatter = buildFormatter(Object.assign(enStrings, {
+    'week': 'a week',
+    'weeks': '%d weeks',
+}));
+
 /* FIXME:
   This isn't the best way to do this, but plugins currently have a lot
   of repetitive goop in their titles.

--- a/src/components/PluginLastReleased.jsx
+++ b/src/components/PluginLastReleased.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import ReactTimeAgo from 'react-time-ago/tooltip';
+import TimeAgo from 'react-timeago';
+import {formatter} from '../commons/helper';
 
 const getTime = (plugin) => {
     if (plugin.releaseTimestamp !== null) {
@@ -18,7 +19,7 @@ function PluginLastReleased({plugin}) {
     return (
         <div>
             {'Last released: '}
-            <ReactTimeAgo date={time} />
+            <TimeAgo date={time} formatter={formatter}/>
         </div>
     );
 }

--- a/src/components/PluginReleases.jsx
+++ b/src/components/PluginReleases.jsx
@@ -1,8 +1,10 @@
 import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
-import ReactTimeAgo from 'react-time-ago/tooltip';
+import TimeAgo from 'react-timeago';
 import './PluginReleases.css';
+import {formatter} from '../commons/helper';
+
 
 function PluginReleases({pluginId}) {
     const [isLoading, setIsLoading] = useState(false);
@@ -35,7 +37,7 @@ function PluginReleases({pluginId}) {
                                 <div>{release.name || release.tag_name}</div>
                                 <div>
                                     {'Released: '}
-                                    <ReactTimeAgo date={new Date(release.published_at)} />
+                                    <TimeAgo date={new Date(release.published_at)} formatter={formatter}/>
                                 </div>
                             </h5>
                         </div>

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -204,14 +204,16 @@ PluginPage.propTypes = {
             }).isRequired,
             version: PropTypes.string
         }).isRequired,
-        reverseDependencies: PropTypes.arrayOf(
-            PropTypes.shape({
-                node: PropTypes.shape({
-                    id: PropTypes.string.isRequired,
-                    title: PropTypes.string.isRequired,
+        reverseDependencies: PropTypes.shape({
+            edges: PropTypes.arrayOf(
+                PropTypes.shape({
+                    node: PropTypes.shape({
+                        id: PropTypes.string.isRequired,
+                        title: PropTypes.string.isRequired,
+                    })
                 })
-            })
-        )
+            )
+        })
     }).isRequired
 };
 

--- a/utils.js
+++ b/utils.js
@@ -18,9 +18,6 @@ async function makeReactLayout() {
         'import SiteVersion from \'./components/SiteVersion\';',
         'import ReportAProblem from \'./components/ReportAProblem\';',
         'import \'./layout.css\';',
-        'import JavascriptTimeAgo from \'javascript-time-ago\';',
-        'import en from \'javascript-time-ago/locale/en\';',
-        'JavascriptTimeAgo.locale(en)'
     ];
 
     const cssLines = [
@@ -29,8 +26,6 @@ async function makeReactLayout() {
         '@import \'./styles/roboto-fonts.css\';',
         '@import \'./styles/base.css\';',
         '@import \'./styles/font-icons.css\';',
-        '@import \'./styles/tooltip.css\';',
-        '@import \'react-time-ago/Tooltip.css\';',
     ];
 
     console.info(`Downloading header file from '${headerUrl}'`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4756,7 +4756,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.3, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5055,11 +5055,6 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
-
-compute-scroll-into-view@^1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz#80e3ebb25d6aa89f42e533956cb4b16a04cfe759"
-  integrity sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5360,14 +5355,6 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
-
-create-react-context@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 cross-fetch@2.2.2:
   version "2.2.2"
@@ -7037,11 +7024,6 @@ executable@^4.1.0:
   dependencies:
     pify "^2.2.0"
 
-exenv@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
-  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
-
 exif-parser@^0.1.12, exif-parser@^0.1.9:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/exif-parser/-/exif-parser-0.1.12.tgz#58a9d2d72c02c1f6f02a0ef4a9166272b7760922"
@@ -7318,7 +7300,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.0, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -10245,13 +10227,6 @@ iterall@^1.2.1, iterall@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
-
-javascript-time-ago@^2.0.2:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.0.7.tgz#ed3e4cfae7059d1c3ecc0e7fc253427f0e120636"
-  integrity sha512-NjM8FNqY91lciAE4bIm6KBW1efDt+0T6+08erwaQRu6SzLov8fJ6623LcyxnBN/Xtf4q9O4s5AMxPtStaNz0rA==
-  dependencies:
-    relative-time-format "^0.1.3"
 
 jest-changed-files@^26.5.0:
   version "26.5.0"
@@ -14130,7 +14105,7 @@ prompts@^2.0.1, prompts@^2.3.2:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14410,18 +14385,6 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-create-ref@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-create-ref/-/react-create-ref-1.0.1.tgz#c0cbeec9e05b608c9f9434fafbecbcc46750293d"
-  integrity sha512-pryn9uefKa5HPfmgf1Gl93+hwN2rqXeipLSdnq6Q9M7Pd00sx617GyOtluqVoQ0XlvvYJ8Bw/uTorXvH+fgUGQ==
-
-react-day-picker@^7.2.4:
-  version "7.4.8"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.8.tgz#675625240d3fae1b41c0a9d5177c968c8517c1d4"
-  integrity sha512-pp0hnxFVoRuBQcRdR1Hofw4CQtOCGVmzCNrscyvS0Q8NEc+UiYLEDqE5dk37bf0leSnBW4lheIt0CKKhuKzDVw==
-  dependencies:
-    prop-types "^15.6.2"
-
 react-dev-utils@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"
@@ -14526,20 +14489,10 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-modal@^3.8.1:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.11.2.tgz#bad911976d4add31aa30dba8a41d11e21c4ac8a4"
-  integrity sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==
-  dependencies:
-    exenv "^1.2.0"
-    prop-types "^15.5.10"
-    react-lifecycles-compat "^3.0.0"
-    warning "^4.0.3"
 
 react-popper@^1.3.6:
   version "1.3.7"
@@ -14605,21 +14558,6 @@ react-remove-scroll@^2.3.0:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-responsive-ui@^0.14.188:
-  version "0.14.188"
-  resolved "https://registry.yarnpkg.com/react-responsive-ui/-/react-responsive-ui-0.14.188.tgz#c7cbbf07dd7d07271f5af3114b2684877dbc8847"
-  integrity sha512-REqh1odrcZhVU5Go236txYST0qltFL1sEkDTzmZUm+pTYFBCJ0Dqv/roxFJmXe3Jg3lsJhUYPGAk5jiVEhrcUQ==
-  dependencies:
-    classnames "^2.2.5"
-    create-react-context "^0.2.2"
-    lodash "^4.17.4"
-    prop-types "^15.7.2"
-    react-create-ref "^1.0.1"
-    react-day-picker "^7.2.4"
-    react-lifecycles-compat "^3.0.2"
-    react-modal "^3.8.1"
-    scroll-into-view-if-needed "^2.2.16"
-
 react-side-effect@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
@@ -14644,14 +14582,10 @@ react-test-renderer@^16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-time-ago@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/react-time-ago/-/react-time-ago-5.0.8.tgz#18a7313e07b987e04b73584bd452f66ec6d8d380"
-  integrity sha512-b4llQ9oWrESc0R+QJ9LXwS0Op2Yks6MvFesSZqr9vaJJ/gn233sK7ld3Ferzo+FNstZo4i60T60DabiIC4nxUQ==
-  dependencies:
-    javascript-time-ago "^2.0.2"
-    prop-types "^15.6.0"
-    react-responsive-ui "^0.14.188"
+react-timeago@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-5.2.0.tgz#d655d40aa55e4fe08a92234481a6aea7f656ab5d"
+  integrity sha512-wCEEDGQHMdFh/PLp+Hj5vk9ZoC4KjQ5u0u6+KrrY9rny5LqJ2gZvNNEAS4mhSZDV1i7JLgQI5VQTAux7f+vj2w==
 
 react-transition-group@^2.3.1:
   version "2.9.0"
@@ -15059,11 +14993,6 @@ regjsparser@^0.6.4:
   integrity sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
   dependencies:
     jsesc "~0.5.0"
-
-relative-time-format@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/relative-time-format/-/relative-time-format-0.1.3.tgz#d50f49d13f97c7f801afba600b1a4a0890755df2"
-  integrity sha512-0O6i4fKjsx8qhz57zorG+LrIDnF9pSvP5s7H9R1Nb5nSqih5dvRyKzNKs6MxhL3bv4iwsz4DuDwAyw+c47QFIA==
 
 remark-footnotes@1.0.0:
   version "1.0.0"
@@ -15651,13 +15580,6 @@ schema-utils@^2.6.5, schema-utils@^2.6.6:
     "@types/json-schema" "^7.0.5"
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
-
-scroll-into-view-if-needed@^2.2.16:
-  version "2.2.25"
-  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.25.tgz#117b7bc7c61bc7a2b7872a0984bc73a19bc6e961"
-  integrity sha512-C8RKJPq9lK7eubwGpLbUkw3lklcG3Ndjmea2PyauzrA0i4DPlzAmVMGxaZrBFqCrVLfvJmP80IyHnv4jxvg1OQ==
-  dependencies:
-    compute-scroll-into-view "^1.0.14"
 
 seek-bzip@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Since [react-time-ago](https://www.npmjs.com/package/react-time-ago) package [can't be updated](https://github.com/jenkins-infra/plugin-site/pull/355) to latest version without changes + it seems to be responsible for some console errors in development mode, why not replace it with 
[react-timeago](https://www.npmjs.com/package/react-timeago) which seems 10x more popular and brings in fewer transitive dependencies. There is also [timeago-react](https://www.npmjs.com/package/timeago-react), but I picked the package with more downloads.

CC @halkeye 