### PR TITLE
Added plugin-release specific styling for release categories.

### DIFF
--- a/src/components/PluginReleases.css
+++ b/src/components/PluginReleases.css
@@ -5,3 +5,7 @@
 #pluginReleases--container .item {
     margin-bottom: 10px;
 }
+
+#pluginReleases--container .card-body .card-text h2 {
+    font-size: 1.2rem;
+}


### PR DESCRIPTION
Related to issue # 

Summary of this pull request: 

closes #262 

See the analysis in #262 for justification of this change, which is localized to the `PluginReleases` component.

Before:

![image](https://user-images.githubusercontent.com/3812023/96068798-d357c900-0e6a-11eb-9ecc-5c1acaeeeb9a.png)


After:

![image](https://user-images.githubusercontent.com/3812023/96068780-c9ce6100-0e6a-11eb-9744-523b5f5b75b2.png)
