### PR TITLE
Search page - Single-column layout is broken on mobile

### DIFF
--- a/src/components/SearchResults.css
+++ b/src/components/SearchResults.css
@@ -29,6 +29,9 @@
     text-align: left;
     text-decoration: none !important;
     width: 13rem;
+    @media (max-width: 768px) {
+        width: calc(100% - 0.4rem);
+    }
     &:hover {
         border: 0.1rem solid #999;
         box-shadow: 0 2px 3px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Fixes #273 

**Summary:**
- On the smaller screens, search-item will cover a full row.

**Desktop Large:**
<img width="800" alt="desktop1" src="https://user-images.githubusercontent.com/7545209/96193477-3ce0e180-0f16-11eb-82cd-76c3e080ee9d.png">

**Desktop Small:**
<img width="600" alt="desktop2" src="https://user-images.githubusercontent.com/7545209/96193482-3f433b80-0f16-11eb-8881-4279b3191a28.png">

**Mobile:**
<img width="400" alt="mobile" src="https://user-images.githubusercontent.com/7545209/96193190-a7dde880-0f15-11eb-834b-9136f82232b6.png">