### PR TITLE
Hacktoberfest: Remove the white strip below the navigation

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -65,9 +65,8 @@ body a:active {color:#c00}
 .NoLabels > .Categories label > input {display:none}
 .NoLabels > .Categories label > span {margin-left:0 !important; color:#0275d8; cursor:pointer}
 
-body #grid-box {padding-top: 30px; }
-@media (min-width: 992px) {
-  body #grid-box {padding-top: 8px; }
+h1.title {
+	margin-top: 1rem;
 }
 
 body #grid-box .NoLabels {padding: 2rem 0; background:#e5f8ff}

--- a/src/templates/search.jsx
+++ b/src/templates/search.jsx
@@ -95,7 +95,7 @@ function SearchPage({location}) {
                     />
                 </div>)}
                 <div className={showFilter ? 'col-md-9' : 'offset-md-1 col-md-11'}>
-                    <div className="row">
+                    <div className="row pt-4">
                         <div className={'col-md-9'}>
                             <SearchBox
                                 showFilter={showFilter}

--- a/utils.js
+++ b/utils.js
@@ -68,7 +68,6 @@ async function makeReactLayout() {
     $('meta[content*="{{"]').remove();
     //
     // padd as per https://stackoverflow.com/questions/11124777/twitter-bootstrap-navbar-fixed-top-overlapping-site
-    $('head').append('<style>{`body { padding-top: 40px; } @media screen and (max-width: 768px) { body { padding-top: 0px; } } `}</style>');
     $('head').append('<style>{`#grid-box { position: relative } `}</style>');
     $('head').append('<style>{`html { min-height:100%; position: relative; }`}</style>');
 
@@ -116,7 +115,7 @@ async function makeReactLayout() {
         } else if (node.type === 'comment') {
             return;
         } else if (node.type === 'text') {
-            const text = node.data;
+            const text = node.data.replace('\u00A0','&nbsp;');
             jsxLines.push(`${prefix}${text}`);
         } else if (node.children && node.children.length) {
             jsxLines.push(`${prefix}<${node.name} ${attrs}>`);


### PR DESCRIPTION
Fixes a design issue with the header.
Before:
![image](https://user-images.githubusercontent.com/1105305/97682315-62cec000-1a98-11eb-93ed-6047b0e78ce0.png)
![image](https://user-images.githubusercontent.com/1105305/97682950-901b6e00-1a98-11eb-9496-b9a9d4cf19cb.png)

After:
![image](https://user-images.githubusercontent.com/1105305/97684053-edafba80-1a98-11eb-9519-9302cb0c32cd.png)
![image](https://user-images.githubusercontent.com/1105305/97684372-091ac580-1a99-11eb-8199-59def61a100a.png)
