### PR TITLE
Make popularity graph start at y=0

### DIFF
--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -13,12 +13,11 @@ const calculateHeight = (total) => {
 };
 
 const calculateMinMax = (data) => {
-    const minValue = Math.min(...data);
     const maxValue = Math.max(...data);
     // calculate a dynamic value to center the graph
     const scaleDifference = Math.pow(10, maxValue.toString().length-1);
     return {
-        min: parseInt(minValue/scaleDifference)*scaleDifference,
+        min: 0,
         max: parseInt((maxValue/scaleDifference)+1)*scaleDifference // plus 1 to add more space in the top
     };
 };


### PR DESCRIPTION
Amends #402 to always start the graph at y=0. Showing a narrower range is misleading at a glance. Even if it shows small differences more clearly, the downside doesn't seem worth it.

FYI @ARUNMOHANRAJ471 

# Example: Showing rapidly changing popularity

While both https://plugins.jenkins.io/trilead-api/ and https://plugins.jenkins.io/okhttp-api/ gained popularity, the relative gains are very different, so should result in different graphs.

## Before

![trilead-api](https://user-images.githubusercontent.com/1831569/97757258-a9ee9c80-1afc-11eb-89a1-74fbc1ce78cc.png)
![okhttp-api](https://user-images.githubusercontent.com/1831569/97757261-ac50f680-1afc-11eb-9d84-16460bde6ccb.png)

## After

![trilead-api](https://user-images.githubusercontent.com/1831569/97757273-b115aa80-1afc-11eb-87e7-366ca6d17fcc.png)
![okhttp-api](https://user-images.githubusercontent.com/1831569/97757276-b3780480-1afc-11eb-921f-06337cb035e7.png)

# Example: Showing fairly unchanging popularity

Additionally, this will now not over-emphasize fairly insignificant differences in reported installation counts.

## Before

![matrix-auth](https://user-images.githubusercontent.com/1831569/97757349-d3a7c380-1afc-11eb-8cdc-61d47fa419a3.png)
![git-parameter](https://user-images.githubusercontent.com/1831569/97757372-defaef00-1afc-11eb-9880-8b819185d62a.png)

## After

![matrix-auth](https://user-images.githubusercontent.com/1831569/97757396-eb7f4780-1afc-11eb-8cd9-03a8312f3ce3.png)
![git-parameter](https://user-images.githubusercontent.com/1831569/97757400-ede1a180-1afc-11eb-8bdc-ba870455e104.png)
