### PR TITLE
Adjust margin/padding for headings and dependency tab

### DIFF
--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -11,7 +11,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
     };
 
     if (!dependencies || dependencies.length === 0) {
-        return (<div className="empty">No dependencies found</div>);
+        return (<div className="empty mt-2">No dependencies found</div>);
     }
     const optionalDependencies = dependencies.filter(dep => dep.optional);
     const impliedDependencies = dependencies.filter(dep => dep.implied && !dep.optional);
@@ -37,7 +37,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
         );
     };
     return (
-        <>
+        <div className="content pb-3">
             <h2>Dependencies</h2>
             <Modal placement="bottom" isOpen={isShowImplied} target="pluginDependencies" toggle={toggleShowImplied}>
                 <ModalHeader toggle={toggleShowImplied}>About Implied Plugin Dependencies</ModalHeader >
@@ -99,7 +99,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
                     reverseDependencies.map(reverseDependencyLink)
                 }
             </div>
-        </>
+        </div>
     );
 }
 

--- a/src/components/PluginIssues.jsx
+++ b/src/components/PluginIssues.jsx
@@ -18,8 +18,10 @@ function PluginIssues({pluginId}) {
     }, []);
 
     if (isLoading) {
-        return (<div className="spinner-border" role="status">
-            <span className="sr-only">Loading...</span>
+        return (<div className="spinner-wrapper">
+            <div className="spinner-border" role="status">
+                <span className="sr-only">Loading...</span>
+            </div>
         </div>);
     }
 

--- a/src/components/PluginReleases.jsx
+++ b/src/components/PluginReleases.jsx
@@ -22,8 +22,10 @@ function PluginReleases({pluginId}) {
     }, []);
 
     if (isLoading) {
-        return (<div className="spinner-border" role="status">
-            <span className="sr-only">Loading...</span>
+        return (<div className="spinner-wrapper">
+            <div className="spinner-border" role="status">
+                <span className="sr-only">Loading...</span>
+            </div>
         </div>);
     }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -55,8 +55,9 @@ body .showResults #plugin-search-form:before {display:none}
     margin-top: .7rem;
 }
 
-.empty {opacity:.33}
-
+.empty {
+	opacity:.5;
+}
 
 body a {color:#069}
 body a:hover {color:#09c}
@@ -115,6 +116,11 @@ transform: scale(-1, 1);
   box-shadow: inset #003399 0 0 1px, inset #ffffff 0 0 0 1px, 0 5px 3px -2px rgba(0, 0, 0, 0.15), inset -5px -5px 7px 1px #168BB9, inset -4px -6px 10px 10px #69c;
 }
 
+.spinner-wrapper {
+	width: 2rem;
+	margin: auto;
+	margin-top: 2rem;
+}
 @-webkit-keyframes ball-l {
   0%, 50% {
     -webkit-transform: rotate(0) translateX(0);
@@ -222,7 +228,6 @@ transform: scale(-1, 1);
 
 .maintainers > .maintainer {display:block;}
 
-.container-fluid.padded {padding:3rem 4rem}
 #pluginPage #grid-box {font-size:.875rem;}
 #pluginPage #grid-box .gutter {padding:2rem }
 #pluginPage #grid-box .gutter > .btn { display:block; text-align:left; padding:.5rem 1rem .75rem 3.5rem; position:relative; margin-bottom:1rem}
@@ -302,10 +307,10 @@ transform: scale(-1, 1);
 }
 
 .markdown-body .anchor {display:none}
-.markdown-body h1 {font-size:2rem; margin:4rem 0 1rem;}
-.markdown-body h2 {font-size:1.5rem; margin-top:2rem;}
-.markdown-body h3 {font-size:1.25rem;}
-.markdown-body h4 {font-size:1.1rem;}
+.content h1 {font-size:2rem; margin:1.5rem 0 1rem;}
+.content h2 {font-size:1.5rem; margin-top:1.5rem;}
+.content h3 {font-size:1.25rem;}
+.content h4 {font-size:1.1rem;}
 
 .filters .mask li > label {opacity:.5; position:relative;}
 .filters .mask li > label:hover {opacity:1; color:#168BB9}

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -69,7 +69,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                             </li>
                         ))}
                     </ul>
-                    <div className="padded">
+                    <div>
                         {state.selectedTab === 'documentation' && (<>
                             {plugin.wiki.content && <div className="content" dangerouslySetInnerHTML={{__html: plugin.wiki.content}} />}
                         </>)}


### PR DESCRIPTION
Fixes #462

Also makes heading styles consistent between documentation and dependencies tab, centers the spinning wheel when loading releases/issues and removes an unused CSS class.

![image](https://user-images.githubusercontent.com/1105305/99147817-2e582800-2684-11eb-9125-ea38f74dc283.png)
![image](https://user-images.githubusercontent.com/1105305/99147840-5cd60300-2684-11eb-9884-33b4614bd4f3.png)


