### PR TITLE
Remove (potential) placeholder from the template

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -72,6 +72,7 @@ async function makeReactLayout() {
     $('head').append('<style>{`html { min-height:100%; position: relative; }`}</style>');
 
     $('.nav-link[href="https://plugins.jenkins.io/"]').attr('href', '/');
+    $('#grid-box').empty();
     $('#grid-box').append('{children}');
     $('#footer .col-md-4').prepend('<ReportAProblem />');
     $('#creativecommons').append('<SiteVersion />');


### PR DESCRIPTION
Has no effect at the moment but will allow placeholder to be inserted in the `grid-box` div so that substitution of `{{ title }}`, `{{ description }}` and content can be done in the same way.