### PR TITLE
Ignore the word 'plugin' when searching for plugins fixes #601

### DIFF
--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -45,6 +45,9 @@ function pluginQueries() {
         settings: {
             paginationLimitedTo: 2000, // they recommend 1000, to keep speed up and prevent people from scraping, but both are fine to us
             attributesToSnippet: ['content:20'],
+            optionalWords: [
+                'plugin'
+            ],
             ranking: [
                 'typo',
                 'geo',


### PR DESCRIPTION
Related to issue #601 

Summary of this pull request: 
I added plugin to stop words (optional words) in the ui and tested the search, it seems to come up with proper results.
