### PR TITLE
Algolia - Allow 'scm plugins' search to return more results

### DIFF
--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -46,7 +46,8 @@ function pluginQueries() {
             paginationLimitedTo: 2000, // they recommend 1000, to keep speed up and prevent people from scraping, but both are fine to us
             attributesToSnippet: ['content:20'],
             optionalWords: [
-                'plugin'
+                'plugin',
+                'plugins'
             ],
             ranking: [
                 'typo',


### PR DESCRIPTION
## Allow 'scm plugins' search to return more results

Related to issue #606

Summary of this pull request: 

Same pattern as the 'plugin' optional word.  Add 'plugins' to the list of optional words.

Without this change, search for "git plugins" returns no results and search for "scm plugins" returns 2 results.  I believe that with this change those searches will return 62 results and 31 results respectively.