### PR TITLE
Algolia - Add 'Jenkins' as an optional word

### DIFF
--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -46,6 +46,7 @@ function pluginQueries() {
             paginationLimitedTo: 2000, // they recommend 1000, to keep speed up and prevent people from scraping, but both are fine to us
             attributesToSnippet: ['content:20'],
             optionalWords: [
+                'jenkins',
                 'plugin',
                 'plugins'
             ],


### PR DESCRIPTION
Words that are likely to appear in every page are not well suited to be search terms

Related to issue #608

Summary of this pull request: 

Make 'Jenkins' an optional word.
