### PR TITLE
Add pipeline step reference link to plugin pages

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -111,6 +111,7 @@ Object {
   "excerpt": "Talks to iOS devices connected to slaves and do stuff.",
   "firstRelease": "2012-10-07T18:59:35.16Z",
   "gav": "org.jenkins-ci.plugins:ios-device-connector:1.2",
+  "hasPipelineSteps": false,
   "id": "ios-device-connector",
   "internal": Object {
     "contentDigest": "7da41342fb756c851d4b5a9b6b6f9f3e",

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -101,16 +101,20 @@ const fetchPluginData = async ({createNode, reporter}) => {
     let page = 1;
     let pluginsContainer;
     const names = [];
+    const pipelinePluginsUrl = 'https://www.jenkins.io/doc/pipeline/steps/contents.json';
+    const pipelinePluginIds = await requestGET({url: pipelinePluginsUrl, reporter});
     do {
         const url = `https://plugins.jenkins.io/api/plugins/?limit=100&page=${page}`;
         pluginsContainer = await requestGET({url, reporter});
 
         for (const plugin of pluginsContainer.plugins) {
-            names.push(plugin.name);
+            const pluginName = plugin.name.trim();
+            names.push(pluginName);
             promises.push(getPluginContent({plugin, reporter}).then(pluginData => {
                 const p = createNode({
                     ...pluginData,
-                    id: pluginData.name.trim(),
+                    id: pluginName,
+                    hasPipelineSteps: pipelinePluginIds.includes(pluginName),
                     parent: null,
                     children: [],
                     internal: {

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -29,6 +29,9 @@ describe('Utils', () => {
         nock('https://updates.jenkins.io')
             .get('/update-center.actual.json')
             .reply(200, {deprecations: []});
+        nock('https://www.jenkins.io')
+            .get('/doc/pipeline/steps/contents.json')
+            .reply(200, []);
         nock('https://plugins.jenkins.io')
             .get('/api/plugins/?limit=100&page=1')
             .reply(200, {

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -33,6 +33,7 @@ export const PluginFragment = graphql`
     scm {
       link
     }
+    hasPipelineSteps
     requiredCore
     releaseTimestamp
     previousVersion

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -105,6 +105,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                     <div className="sidebarSection">
                         <h5>Links</h5>
                         {plugin.scm && plugin.scm.link && <div className="label-link"><a href={plugin.scm.link}>GitHub</a></div>}
+                        {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline step reference</a></div>}
                         <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
                     </div>
                     <div className="sidebarSection">

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -105,7 +105,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                     <div className="sidebarSection">
                         <h5>Links</h5>
                         {plugin.scm && plugin.scm.link && <div className="label-link"><a href={plugin.scm.link}>GitHub</a></div>}
-                        {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline step reference</a></div>}
+                        {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline Step Reference</a></div>}
                         <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
                     </div>
                     <div className="sidebarSection">


### PR DESCRIPTION
Adds a link to the pipeline documentation of given plugin (if it exists).

![image](https://user-images.githubusercontent.com/1105305/117890094-d279ff00-b2b4-11eb-831b-4fb796bdfdbd.png)
