### PR TITLE
Mobile layout improvements

### DIFF
--- a/src/components/Pages.jsx
+++ b/src/components/Pages.jsx
@@ -27,7 +27,7 @@ export default class Pages extends React.PureComponent {
               breakClassName={'page-item disabled'}
               breakLinkClassName={'page-link'}
 
-              pageClassName={'page-item'}
+              pageClassName={'page-item d-none d-sm-block'}
               pageLinkClassName={'page-link'}
               nextClassName={'page-item'}
               nextLinkClassName={'page-link'}

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -14,7 +14,7 @@ function Pagination({limit, page, pages, total, setPage}) {
     return (
         <>
             <div className="row nav-link">
-                {`${start} to ${end} of ${total}`}
+                {`${start+1} to ${end} of ${total}`}
             </div>
             {pages > 1 &&
                 <Pages

--- a/src/components/SearchResults.css
+++ b/src/components/SearchResults.css
@@ -161,13 +161,9 @@
     }
 }
 .SearchResults--List {
-    &.SearchResults--GridBox {
-        display: table;
-    }
     & .SearchResults--ItemBox {
         height: initial;
         min-height: initial;
-        width: initial;
     }
     & .Plugin--IconContainer {
         bottom: initial;
@@ -185,37 +181,8 @@
             position: initial;
         }
     }
-}
-.SearchResults--Table {
-    &.SearchResults--GridBox {
-        display: table;
-    }
-    & .SearchResults--ItemBox {
+    & .Plugin--ExcerptContainer {
         height: initial;
-        min-height: initial;
-        width: initial;
-    }
-    & .Plugin--PluginContainer {
-        display: grid;
-        grid-gap: 1em;
-        grid-template-areas: "title installs version labels excerpt authors";
-        grid-template-columns: 15em 5em 7em 7em 1fr 5em;
-
-        @media (max-width: 992px) {
-            grid-template-areas: "title" "installs" "version" "labels" "excerpt" "authors";
-        }
-        & .Plugin--IconContainer {
-            display: none;
-            visibility: hidden;
-        }
-        & .Plugin--AuthorsContainer {
-            position: initial;
-        }
-        & .Plugin--LabelsContainer {
-            margin: 0;
-            & .label-link {
-                display: block;
-            }
-        }
+        margin-bottom: 1rem;
     }
 }

--- a/src/components/Views.jsx
+++ b/src/components/Views.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import View from './View';
 
-const views = ['Tiles', 'List', 'Table'];
+const views = ['Tiles', 'List'];
 
 function Views({view, setView}) {
     return (

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -252,16 +252,15 @@ transform: scale(-1, 1);
 .maintainers > .maintainer {display:block;}
 
 #pluginPage #grid-box {font-size:.875rem;}
-#pluginPage #grid-box .gutter {padding:2rem }
-#pluginPage #grid-box .gutter > .btn { display:block; text-align:left; padding:.5rem 1rem .75rem 3.5rem; position:relative; margin-bottom:1rem}
-#pluginPage #grid-box .gutter > .btn i {font-size:2.25rem; position:absolute; left:.75rem; top:.5rem}
-#pluginPage #grid-box .gutter > .btn > span {font-size:1.1rem; line-height:1.3rem; font-weight:500}
-#pluginPage #grid-box .gutter > .btn > .v {display:block; font-weight:200; font-size:.75rem; white-space:normal}
-#pluginPage #grid-box .gutter .lbl {display:inline-block; margin-right:.5rem}
-##pluginPage #grid-box .gutter .label-link a{display:block; line-height: 1.5rem; padding: 4px 0;}
-#pluginPage #grid-box .gutter .chart {margin:1rem 0 0}
+#pluginPage #grid-box .sidebar > .btn { display:block; text-align:left; padding:.5rem 1rem .75rem 3.5rem; position:relative; margin-bottom:1rem}
+#pluginPage #grid-box .sidebar > .btn i {font-size:2.25rem; position:absolute; left:.75rem; top:.5rem}
+#pluginPage #grid-box .sidebar > .btn > span {font-size:1.1rem; line-height:1.3rem; font-weight:500}
+#pluginPage #grid-box .sidebar > .btn > .v {display:block; font-weight:200; font-size:.75rem; white-space:normal}
+#pluginPage #grid-box .sidebar .lbl {display:inline-block; margin-right:.5rem}
+##pluginPage #grid-box .sidebar .label-link a{display:block; line-height: 1.5rem; padding: 4px 0;}
+#pluginPage #grid-box .sidebar .chart {margin:1rem 0 0}
 
-.gutter .sidebarSection {
+.sidebar .sidebarSection {
   margin-top: 1rem;
   padding-top:.5rem;
   border-top: 1px #AAA solid;
@@ -322,6 +321,9 @@ transform: scale(-1, 1);
   justify-content: space-between;
   align-items: center;
   margin-top: 1rem;
+  max-width: 72rem;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 .plugin-id {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -32,6 +32,10 @@ body .showResults #plugin-search-form p,
 body .showResults #plugin-search-form h1,
 body .showResults #plugin-search-form:before {display:none}
 
+.page-link {
+  cursor: pointer
+}
+
 .CategoryList,
 .CategoryList ul{
   padding:0;

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -48,18 +48,17 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
     return (
         <Layout id="pluginPage" reportProblemRelativeSourcePath={pluginPage} reportProblemUrl={`/${plugin.name}`} reportProblemTitle={plugin.title}>
             <SEO title={cleanTitle(plugin.title)} description={plugin.excerpt} pathname={`/${plugin.id}`}/>
-
+            <div className="title-wrapper">
+                <h1 className="title">
+                    {cleanTitle(plugin.title)}
+                </h1>
+                <div className="plugin-id">
+                    {'ID: '}
+                    {plugin.name}
+                </div>
+            </div>
             <div className="row flex pluginContainer flex-column-reverse flex-md-row">
                 <div className="col-md-9 main">
-                    <div className="title-wrapper">
-                        <h1 className="title">
-                            {cleanTitle(plugin.title)}
-                        </h1>
-                        <div className="plugin-id">
-                            {'ID: '}
-                            {plugin.name}
-                        </div>
-                    </div>
                     <PluginActiveWarnings securityWarnings={plugin.securityWarnings} />
                     <PluginGovernanceStatus plugin={plugin} />
                     <ul className="nav nav-tabs">
@@ -79,7 +78,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                             reverseDependencies={reverseDependencies.edges.map(dep => dep.node)}/>}
                     </div>
                 </div>
-                <div className="col-md-3 gutter">
+                <div className="col-md-3 sidebar">
                     <h5>{`Version: ${plugin.version}`}</h5>
                     <PluginLastReleased plugin={plugin} />
                     <div>

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -49,7 +49,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
         <Layout id="pluginPage" reportProblemRelativeSourcePath={pluginPage} reportProblemUrl={`/${plugin.name}`} reportProblemTitle={plugin.title}>
             <SEO title={cleanTitle(plugin.title)} description={plugin.excerpt} pathname={`/${plugin.id}`}/>
 
-            <div className="row flex pluginContainer">
+            <div className="row flex pluginContainer flex-column-reverse flex-md-row">
                 <div className="col-md-9 main">
                     <div className="title-wrapper">
                         <h1 className="title">
@@ -80,11 +80,6 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                     </div>
                 </div>
                 <div className="col-md-3 gutter">
-                    <a href="#releases" onClick={() => setState({selectedTab: 'releases'})} className="btn btn-secondary">
-                        <i className="icon-box" />
-                        <span>Archives</span>
-                        <span className="v">Get past versions</span>
-                    </a>
                     <h5>{`Version: ${plugin.version}`}</h5>
                     <PluginLastReleased plugin={plugin} />
                     <div>


### PR DESCRIPTION
Related to issue #273, #483 

Summary of this pull request: 
* swap metadata and description on mobile
* remove the archives link (duplicates "releases" tab)
* make list view for search more responsive
* remove table view for search (nearly identical to list view)
* fix ranges in pagination (should be "1 to 50", "51 to 100", not "0 to 50", "50 to 100") 

