### PR TITLE
Adds a dev section to the bottom of the dependency tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,8 @@
         "stylelint-config-styled-components": "^0.1.1",
         "stylelint-order": "^4.1.0",
         "stylelint-processor-styled-components": "^1.10.0",
-        "stylelint-selector-bem-pattern": "^2.1.0"
+        "stylelint-selector-bem-pattern": "^2.1.0",
+        "xml2js": "^0.4.23"
       },
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-order": "^4.1.0",
     "stylelint-processor-styled-components": "^1.10.0",
-    "stylelint-selector-bem-pattern": "^2.1.0"
+    "stylelint-selector-bem-pattern": "^2.1.0",
+    "xml2js": "^0.4.23"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -111,6 +111,7 @@ Object {
   "excerpt": "Talks to iOS devices connected to slaves and do stuff.",
   "firstRelease": "2012-10-07T18:59:35.16Z",
   "gav": "org.jenkins-ci.plugins:ios-device-connector:1.2",
+  "hasBomEntry": false,
   "hasPipelineSteps": false,
   "id": "ios-device-connector",
   "internal": Object {

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -32,6 +32,9 @@ describe('Utils', () => {
         nock('https://www.jenkins.io')
             .get('/doc/pipeline/steps/contents.json')
             .reply(200, []);
+        nock('https://raw.githubusercontent.com:443')
+            .get('/jenkinsci/bom/master/bom-latest/pom.xml')
+            .reply(200, '');
         nock('https://plugins.jenkins.io')
             .get('/api/plugins/?limit=100&page=1')
             .reply(200, {

--- a/src/components/ClipboardButton.jsx
+++ b/src/components/ClipboardButton.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useCopyToClipboard from '../hooks/useCopyToClipboard';
+import src from '../images/clipboard.svg';
+import {copyWrapper, copySuccess} from './ClipboardButton.module.css';
+import classNames from 'classnames';
+
+function ClipboardButton({content}) {
+    const [isCopied, handleCopy] = useCopyToClipboard(3000);
+    return (<div className={copyWrapper}>
+        {isCopied && (<div className={classNames('alert', 'alert-success', copySuccess)}>{'Copied to clipboard'}</div>)}
+        <button className="btn" onClick={()=>handleCopy(content)} aria-label="Copy to clipboard">
+            <img src={src} alt=""/>
+        </button>
+    </div>);
+}
+
+ClipboardButton.propTypes = {
+    content: PropTypes.string.isRequired
+};
+
+export default ClipboardButton;

--- a/src/components/ClipboardButton.module.css
+++ b/src/components/ClipboardButton.module.css
@@ -1,0 +1,13 @@
+.copy-wrapper {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  min-height: 3rem;
+}
+
+.copy-success {
+    position: absolute;
+    right: 4rem;
+    white-space: nowrap;
+    line-height: 1rem;
+}

--- a/src/components/InstallViaCLI.jsx
+++ b/src/components/InstallViaCLI.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useCopyToClipboard from '../hooks/useCopyToClipboard';
-import {root, copy} from './InstallViaCLI.module.css';
+import {root} from './InstallViaCLI.module.css';
+import ClipboardButton from './ClipboardButton';
 
 function InstallViaCLI({pluginId, version}) {
     // isCopied is reset after 3 second timeout
-    const [isCopied, handleCopy] = useCopyToClipboard(3000);
     const body = `jenkins-plugin-cli --plugins ${pluginId}:${version}`;
 
     return (
@@ -15,10 +14,10 @@ function InstallViaCLI({pluginId, version}) {
                 <a href="https://github.com/jenkinsci/plugin-installation-manager-tool">cli</a>
                 {': '}
             </span>
-            <code className={copy} title="click to copy" onClick={() => handleCopy(body)}>
+            <code>
                 {body}
             </code>
-            {isCopied && (<span>{' Copied '}</span>)}
+            <ClipboardButton content={body}/>
         </div>
     );
 }

--- a/src/components/InstallViaCLI.module.css
+++ b/src/components/InstallViaCLI.module.css
@@ -1,6 +1,8 @@
+.root {
+    position: relative;
+    line-height: 3rem;
+}
+
 .root span {
     margin-right: 5px;
-}
-.copy {
-    cursor: pointer;
 }

--- a/src/components/MavenDependency.jsx
+++ b/src/components/MavenDependency.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ClipboardButton from './ClipboardButton';
+
+function MavenDependency({gav, hasBomEntry} ) {
+    const [group, artifactId, version] = gav.split(':');
+    const snippet = `<dependency>
+    <groupId>${group}</groupId>
+    <artifactId>${artifactId}</artifactId>${hasBomEntry ? '':`\n    <version>${version}</version>`}
+</dependency>`;
+    return (
+        <>
+            <h3>Declaring a dependency</h3>
+            <p>As a plugin developer you can use this plugin as dependency of your plugin by adding a dependency tag to your POM.</p>
+            {!hasBomEntry && <p>To add the latest version of this plugin as a maven dependency, use the following:</p>}
+            {hasBomEntry && <p>
+                <>
+                    To avoid version conflicts it is suggested not to depend on a specific version, but use the
+                    {' '}
+                    <a href="https://github.com/jenkinsci/bom#readme">Jenkins plugin BOM</a>
+                    {' '}
+                    and the following depndency snippet:
+                </>
+            </p>}
+            <div className="code-wrapper position-relative">
+                <pre>
+                    {snippet}
+                </pre>
+                <ClipboardButton content={snippet}/>
+            </div>
+        </>
+    );
+}
+
+MavenDependency.propTypes = {
+    gav: PropTypes.string.isRequired,
+    hasBomEntry: PropTypes.bool
+};
+
+export default MavenDependency;

--- a/src/components/MavenDependency.jsx
+++ b/src/components/MavenDependency.jsx
@@ -19,7 +19,7 @@ function MavenDependency({gav, hasBomEntry} ) {
                     {' '}
                     <a href="https://github.com/jenkinsci/bom#readme">Jenkins plugin BOM</a>
                     {' '}
-                    and the following depndency snippet:
+                    and the following dependency snippet:
                 </>
             </p>}
             <div className="code-wrapper position-relative">

--- a/src/components/PluginDependencies.jsx
+++ b/src/components/PluginDependencies.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'gatsby';
+import MavenDependency from './MavenDependency';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 
-function PluginDependencies({dependencies, reverseDependencies} ) {
+function PluginDependencies({dependencies, reverseDependencies, gav, hasBomEntry} ) {
     const [isShowImplied, setShowImplied] = React.useState(false);
     const toggleShowImplied = (e) => {
         e && e.preventDefault();
@@ -95,6 +96,7 @@ function PluginDependencies({dependencies, reverseDependencies} ) {
                     : (<div className="empty">No dependencies found</div>)
             }
             <h2>Dependent plugins</h2>
+            <MavenDependency gav={gav} hasBomEntry={hasBomEntry}/>
             {
                 reverseDependencies.length ? splitByType(reverseDependencies, reverseDependencyLink)
                     : (<div className="empty">No dependent plugins found</div>)
@@ -120,7 +122,9 @@ PluginDependencies.propTypes = {
             optional: PropTypes.bool,
             implied: PropTypes.bool,
         })
-    )
+    ),
+    gav: PropTypes.string,
+    hasBomEntry: PropTypes.bool
 };
 
 export default PluginDependencies;

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -4,6 +4,7 @@ export const PluginFragment = graphql`
   fragment JenkinsPluginFragment on JenkinsPlugin {
     id
     gav
+    hasBomEntry
     title
     url
     version

--- a/src/images/clipboard.svg
+++ b/src/images/clipboard.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -943,7 +943,7 @@ a.card:hover {
   padding: 1em;
 }
 
-.markdown-body pre {
+.markdown-body pre, .code-wrapper pre {
   background-color: rgb(246, 248, 250);
   padding: 16px;
   border-radius: 4px;

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -97,7 +97,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                                 installations={plugin.stats.installations}
                             />
                         </div>
-                        <div className="label-link"><a href={`https://stats.jenkins.io/pluginversions/${plugin.name}.html`}>Installs by version</a></div>
+                        <div className="label-link"><a href={`https://stats.jenkins.io/pluginversions/${plugin.name}.html`}>View detailed version information</a></div>
                     </div>
                     <div className="sidebarSection">
                         <h5>Links</h5>

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -7,6 +7,7 @@ import {cleanTitle} from '../commons/helper';
 import Layout from '../layout';
 import SEO from '../components/SEO';
 import LineChart from '../components/LineChart';
+import MavenDependency from '../components/MavenDependency';
 import PluginDependencies from '../components/PluginDependencies';
 import PluginLabels from '../components/PluginLabels';
 import PluginLastReleased from '../components/PluginLastReleased';
@@ -74,8 +75,11 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                         </>)}
                         {state.selectedTab === 'releases' && <PluginReleases pluginId={plugin.id} versions={versions.edges.map(edge => edge.node)} />}
                         {state.selectedTab === 'issues' && <PluginIssues pluginId={plugin.id} />}
-                        {state.selectedTab === 'dependencies' && <PluginDependencies dependencies={plugin.dependencies}
-                            reverseDependencies={reverseDependencies.edges.map(dep => dep.node)}/>}
+                        {state.selectedTab === 'dependencies' && <>
+                            <PluginDependencies dependencies={plugin.dependencies}
+                                reverseDependencies={reverseDependencies.edges.map(dep => dep.node)}/>
+                            <MavenDependency gav={plugin.gav} hasBomEntry={plugin.hasBomEntry}/>
+                        </>}
                     </div>
                 </div>
                 <div className="col-md-3 sidebar">
@@ -95,6 +99,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                                 installations={plugin.stats.installations}
                             />
                         </div>
+                        <div className="label-link"><a href={`https://stats.jenkins.io/pluginversions/${plugin.name}.html`}>Installs by version</a></div>
                     </div>
                     <div className="sidebarSection">
                         <h5>Links</h5>
@@ -168,6 +173,8 @@ PluginPage.propTypes = {
                 version: PropTypes.string
             })),
             excerpt: PropTypes.string,
+            gav: PropTypes.string.isRequired,
+            hasBomEntry: PropTypes.bool,
             labels: PropTypes.arrayOf(PropTypes.string),
             maintainers: PropTypes.arrayOf(PropTypes.shape({
                 id: PropTypes.string,

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -7,7 +7,6 @@ import {cleanTitle} from '../commons/helper';
 import Layout from '../layout';
 import SEO from '../components/SEO';
 import LineChart from '../components/LineChart';
-import MavenDependency from '../components/MavenDependency';
 import PluginDependencies from '../components/PluginDependencies';
 import PluginLabels from '../components/PluginLabels';
 import PluginLastReleased from '../components/PluginLastReleased';
@@ -75,11 +74,10 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                         </>)}
                         {state.selectedTab === 'releases' && <PluginReleases pluginId={plugin.id} versions={versions.edges.map(edge => edge.node)} />}
                         {state.selectedTab === 'issues' && <PluginIssues pluginId={plugin.id} />}
-                        {state.selectedTab === 'dependencies' && <>
-                            <PluginDependencies dependencies={plugin.dependencies}
-                                reverseDependencies={reverseDependencies.edges.map(dep => dep.node)}/>
-                            <MavenDependency gav={plugin.gav} hasBomEntry={plugin.hasBomEntry}/>
-                        </>}
+                        {state.selectedTab === 'dependencies' && <PluginDependencies dependencies={plugin.dependencies}
+                            reverseDependencies={reverseDependencies.edges.map(dep => dep.node)}
+                            hasBomEntry={plugin.hasBomEntry}
+                            gav={plugin.gav}/>}
                     </div>
                 </div>
                 <div className="col-md-3 sidebar">


### PR DESCRIPTION
Related to issue https://issues.jenkins.io/browse/WEBSITE-386

Adds a dev section to the bottom of the dependency tab:

<details><summary>Plugin in BOM</summary>

![image](https://user-images.githubusercontent.com/1105305/121258542-5375e780-c8af-11eb-98e0-2310d5e84992.png)

</details>

<details><summary>Standard plugin</summary>

![image](https://user-images.githubusercontent.com/1105305/121258635-6ee0f280-c8af-11eb-8b56-e588665a0867.png)
</details>

... and a link to detailed usage stats in the sidebar
<details><summary>Same for all plugins</summary>

![image](https://user-images.githubusercontent.com/1105305/121258689-7f916880-c8af-11eb-8021-48b87f777830.png)

</details>

CC @daniel-beck



