### PR TITLE
Set home dir for npm cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ def runDockerCommand(image, cmd) {
       --network host \
       --rm -e GET_CONTENT \
       -w "\$PWD" \
+      -e HOME="\$PWD"
       -v "\$PWD:\$PWD" \
       -u \$(id -u):\$(id -g) \
       $image \


### PR DESCRIPTION
trying to fix "Your cache folder contains root-owned files" error