### PR TITLE
Revert "Plausible support"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -47,7 +47,6 @@ spec:
   environment {
     GET_CONTENT = "true"
     NODE_ENV = "production"
-    GATSBY_PLAUSIBLE_KEY = "plugins.jenkins.io"
     HOME = "${WORKSPACE}"
   }
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,12 +49,6 @@ module.exports = {
                 showSpinner: false,
             },
         },
-        {
-            resolve: 'gatsby-plugin-plausible',
-            options: {
-                domain: process.env.GATSBY_PLAUSIBLE_KEY,
-            },
-        },
         process.env.GATSBY_ALGOLIA_WRITE_KEY ? {
             resolve: 'gatsby-plugin-algolia',
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "find-package-json": "^1.2.0",
         "gatsby-plugin-canonical-urls": "^3.6.0",
         "gatsby-plugin-image": "^1.6.0",
-        "gatsby-plugin-plausible": "^0.0.7",
         "gatsby-plugin-postcss": "^4.6.0",
         "gatsby-plugin-react-helmet": "^4.6.0",
         "gatsby-plugin-robots-txt": "^1.6.2",
@@ -13102,34 +13101,6 @@
       },
       "peerDependencies": {
         "gatsby": "^3.0.0-next.0"
-      }
-    },
-    "node_modules/gatsby-plugin-plausible": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-plausible/-/gatsby-plugin-plausible-0.0.7.tgz",
-      "integrity": "sha512-pWCXsrWal8lWMmZ1wJ2dolbwZZR1CZU1LVR/K1rYC8NeA+uqTLY8h3uH3hFgP5n8jmRRenOSJ9SjWM9OIdCjOA==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2",
-        "minimatch": "3.0.4",
-        "react": "^16.13.1"
-      },
-      "peerDependencies": {
-        "gatsby": ">=2.0.0",
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/gatsby-plugin-plausible/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/gatsby-plugin-postcss": {
@@ -49350,28 +49321,6 @@
         "gatsby-telemetry": "^2.6.0",
         "globby": "^11.0.3",
         "lodash": "^4.17.21"
-      }
-    },
-    "gatsby-plugin-plausible": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-plausible/-/gatsby-plugin-plausible-0.0.7.tgz",
-      "integrity": "sha512-pWCXsrWal8lWMmZ1wJ2dolbwZZR1CZU1LVR/K1rYC8NeA+uqTLY8h3uH3hFgP5n8jmRRenOSJ9SjWM9OIdCjOA==",
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "minimatch": "3.0.4",
-        "react": "^16.13.1"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        }
       }
     },
     "gatsby-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "find-package-json": "^1.2.0",
     "gatsby-plugin-canonical-urls": "^3.6.0",
     "gatsby-plugin-image": "^1.6.0",
-    "gatsby-plugin-plausible": "^0.0.7",
     "gatsby-plugin-postcss": "^4.6.0",
     "gatsby-plugin-react-helmet": "^4.6.0",
     "gatsby-plugin-robots-txt": "^1.6.2",


### PR DESCRIPTION
My plausible subscription is not big enough to cover plugins.jenkins.io views
I am rollbacking this, for now, more context [here](https://community.jenkins.io/t/analytics-for-plugins-jenkins-io-matomo/169/20?u=olblak)

Reverts jenkins-infra/plugin-site#725