### PR TITLE
Switch labels, categories and detachments to UC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
         'import'
     ],
     'rules': {
+        'comma-spacing': 2,
         'eol-last': 2,
         'import/extensions': ['error', 'ignorePackages', {'js': 'never', 'jsx': 'never'}],
         'import/no-unresolved': [2],
@@ -73,7 +74,7 @@ module.exports = {
         'react/react-in-jsx-scope': 2,
         'react/self-closing-comp': 2,
         'semi': [2],
-        'space-before-function-paren': [2, {'anonymous': 'always','named': 'never'}],
+        'space-before-function-paren': [2, {'anonymous': 'always', 'named': 'never'}],
         'strict': [2, 'global'],
     },
     'settings': {

--- a/plugins/gatsby-source-jenkinsplugins/__mocks__/split-plugins.txt
+++ b/plugins/gatsby-source-jenkinsplugins/__mocks__/split-plugins.txt
@@ -1,0 +1,36 @@
+# See ClassicPluginStrategy.DETACHED_LIST. As of JENKINS-47634 also used by plugin-compat-tester.
+
+# Columns are: plugin ID, last core release still containing the plugin's functionality, plugin version that's implied, minimum Java specification version where to install the plugin
+
+# Note that all split plugins between and including matrix-auth and jaxb incorrectly use the first
+# core release without the plugin's functionality when they should use the immediately prior release.
+# Fixing these retroactively won't help, as the difference only matters to those specific versions.
+
+maven-plugin 1.296 1.296
+subversion 1.310 1.0
+cvs 1.340 0.1
+ant 1.430 1.0
+javadoc 1.430 1.0
+external-monitor-job 1.467 1.0
+ldap 1.467 1.0
+pam-auth 1.467 1.0
+mailer 1.493 1.2
+matrix-auth 1.535 1.0.2
+windows-slaves 1.547 1.0
+antisamy-markup-formatter 1.553 1.0
+matrix-project 1.561 1.0
+junit 1.577 1.0
+bouncycastle-api 2.16 2.16.0
+# JENKINS-47393
+command-launcher 2.86 1.0
+# JENKINS-22367
+jdk-tool 2.112 1.0
+
+# JENKINS-55681
+jaxb 2.163 2.3.0 11
+
+#JENKINS-43610 Split Trilead out from Core
+trilead-api 2.184 1.0.4
+
+# JENKINS-64107
+sshd 2.281 3.0.1

--- a/plugins/gatsby-source-jenkinsplugins/__mocks__/update-center.actual.json
+++ b/plugins/gatsby-source-jenkinsplugins/__mocks__/update-center.actual.json
@@ -1,0 +1,84 @@
+{
+  "deprecations": [],
+  "warnings": [],
+  "plugins": {
+    "ios-device-connector": {
+      "buildDate": "Oct 10, 2012",
+      "defaultBranch": "master",
+      "dependencies": [],
+      "developers": [],
+      "excerpt": "Talks to iOS devices connected to slaves and do stuff.",
+      "gav": "org.jenkins-ci.plugins:ios-device-connector:1.2",
+      "issueTrackers": [
+        {
+          "reportUrl": "https://www.jenkins.io/participate/report-issue/redirect/#17020",
+          "type": "jira",
+          "viewUrl": "https://issues.jenkins.io/issues/?jql=component=17020"
+        }
+      ],
+      "labels": [
+        "builder",
+        "ios"
+      ],
+      "name": "ios-device-connector",
+      "popularity": 275,
+      "previousTimestamp": "2012-10-08T20:04:36.00Z",
+      "previousVersion": "1.1",
+      "releaseTimestamp": "2012-10-10T17:27:42.00Z",
+      "requiredCore": "1.466",
+      "scm": "https://github.com/jenkinsci/ios-device-connector-plugin",
+      "sha1": "B2z2wTyA8l5uwz9HqD+xhG9Hjns=",
+      "sha256": "Tray3+tyfE6xoTu1Rge9+INkcj5y7Bgw7nPm//saiYw=",
+      "size": 1548862,
+      "title": "iOS Device connector",
+      "url": "https://updates.jenkins.io/download/plugins/ios-device-connector/1.2/ios-device-connector.hpi",
+      "version": "1.2",
+      "wiki": "https://plugins.jenkins.io/ios-device-connector"
+    },
+    "external-monitor-job": {
+      "title": "External Monitor Job Type"
+    },
+    "ldap": {
+      "title": "LDAP"
+    },
+    "pam-auth": {
+      "title": "PAM Authentication"
+    },
+    "mailer": {
+      "title": "Mailer"
+    },
+    "matrix-auth": {
+      "title": "Matrix Authorization Strategy"
+    },
+    "windows-slaves": {
+      "title": "WMI Windows Agents"
+    },
+    "antisamy-markup-formatter": {
+      "title": "OWASP Markup Formatter"
+    },
+    "matrix-project": {
+      "title": "Matrix Project"
+    },
+    "junit": {
+      "title": "JUnit"
+    },
+    "bouncycastle-api": {
+      "title": "bouncycastle API"
+    },
+    "command-launcher": {
+      "title": "Command Agent Launcher"
+    },
+    "jdk-tool": {
+      "title": "Oracle Java SE Development Kit Installer"
+    },
+    "jaxb": {
+      "title": "JAXB"
+    },
+    "trilead-api": {
+      "title": "Trilead API"
+    },
+    "sshd": {
+      "title": "SSHD"
+    }
+  }
+}

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -3,10 +3,6 @@
 exports[`Utils Get plugin data for a wiki based plugin 1`] = `
 Object {
   "buildDate": "Oct 10, 2012",
-  "categories": Array [
-    "buildManagement",
-    "languagesPlatforms",
-  ],
   "children": Array [],
   "defaultBranch": "master",
   "dependencies": Array [

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -4,8 +4,8 @@ exports[`Utils Get plugin data for a wiki based plugin 1`] = `
 Object {
   "buildDate": "Oct 10, 2012",
   "categories": Array [
-    "languagesPlatforms",
     "buildManagement",
+    "languagesPlatforms",
   ],
   "children": Array [],
   "defaultBranch": "master",
@@ -107,6 +107,13 @@ Object {
       "optional": false,
       "title": "Trilead API",
       "version": "1.0.4",
+    },
+    Object {
+      "implied": true,
+      "name": "sshd",
+      "optional": false,
+      "title": "SSHD",
+      "version": "3.0.1",
     },
   ],
   "developers": Array [],

--- a/plugins/gatsby-source-jenkinsplugins/categories.json
+++ b/plugins/gatsby-source-jenkinsplugins/categories.json
@@ -1,0 +1,68 @@
+[
+    {
+        "id": "languagesPlatforms",
+        "title": "Platforms",
+        "description": "Jenkins plugins that are designed to give added support for building, testing or deploying to specific languages or platforms.",
+        "labels":
+        [
+            "ios",
+            "dotnet",
+            "android",
+            "ruby"
+        ]
+    },
+
+    {
+        "id": "userInterface",
+        "title": "User interface",
+        "description": "Add-ons designed to make your iteraction with Jenkins better.",
+        "labels":
+        [
+            "ui",
+            "listview-column"
+        ]
+    },
+
+    {
+        "id": "adminTools",
+        "title": "Administration",
+        "description": "Add functionality to help streamline your administration of Jenkins.",
+        "labels":
+        [
+            "slaves",
+            "page-decorator",
+            "user",
+            "cluster",
+            "cli"
+        ]
+    },
+
+    {
+        "id": "scm",
+        "title": "Source code management",
+        "description": "Connect to your Jenkins to your SCM.",
+        "labels":
+        [
+            "scm",
+            "scm-related"
+        ]
+    },
+
+    {
+        "id": "buildManagement",
+        "title": "Build management",
+        "description": "Add new means of trigger jobs and new ways to ensure environment consistency for you automated processes.",
+        "labels":
+        [
+            "trigger",
+            "buildwrapper",
+            "notifier",
+            "deployment",
+            "parameter",
+            "post-build",
+            "builder",
+            "report",
+            "upload"
+        ]
+    }
+]

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
@@ -14,13 +14,12 @@ exports.sourceNodes = async (
 
     try {
         const firstReleases = {};
-        const labelToCategory = {};
         await Promise.all([
             fetchSiteInfo({createNode, reporter}),
-            processCategoryData({createNode, reporter, labelToCategory}),
+            processCategoryData({createNode, reporter}),
             fetchLabelData({createNode, reporter}),
             fetchPluginVersions({createNode, reporter, firstReleases}),
-        ]).then(() => fetchPluginData({createNode, reporter, firstReleases, labelToCategory}));
+        ]).then(() => fetchPluginData({createNode, reporter, firstReleases}));
     } catch (err) {
         reporter.panic(
             `gatsby-source-jenkinsplugin: Failed to parse API call -  ${err.stack || err}`

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
@@ -2,7 +2,7 @@ const {
     fetchSiteInfo,
     fetchPluginData,
     fetchPluginVersions,
-    fetchCategoryData,
+    processCategoryData,
     fetchLabelData,
 } = require('./utils');
 
@@ -14,12 +14,13 @@ exports.sourceNodes = async (
 
     try {
         const firstReleases = {};
+        const labelToCategory = {};
         await Promise.all([
             fetchSiteInfo({createNode, reporter}),
-            fetchCategoryData({createNode, reporter}),
+            processCategoryData({createNode, reporter, labelToCategory}),
             fetchLabelData({createNode, reporter}),
             fetchPluginVersions({createNode, reporter, firstReleases}),
-        ]).then(() => fetchPluginData({createNode, reporter, firstReleases}));
+        ]).then(() => fetchPluginData({createNode, reporter, firstReleases, labelToCategory}));
     } catch (err) {
         reporter.panic(
             `gatsby-source-jenkinsplugin: Failed to parse API call -  ${err.stack || err}`

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -96,8 +96,6 @@ const getPluginContent = async ({plugin, reporter}) => {
     });
 };
 
-const unique = (value, index, self) => self.indexOf(value) === index;
-
 const fetchPluginData = async ({createNode, reporter, firstReleases, labelToCategory}) => {
     const sectionActivity = reporter.activityTimer('fetch plugins info');
     sectionActivity.start();
@@ -130,7 +128,7 @@ const fetchPluginData = async ({createNode, reporter, firstReleases, labelToCate
                     securityWarnings: updateData.warnings.filter(p => p.name == pluginName)
                         .map(w => checkActive(w, pluginUC)),
                     dependencies: pluginUC.dependencies.concat(getImpliedDependencies(plugin, detachedPlugins, updateData)),
-                    categories: pluginUC.labels.map(label => labelToCategory[label]).filter(unique),
+                    categories: Array.from(new Set(pluginUC.labels.map(label => labelToCategory[label]))),
                     firstRelease: firstReleases[pluginName].toISOString(),
                     id: pluginName,
                     hasPipelineSteps: pipelinePluginIds.includes(pluginName),

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -96,7 +96,7 @@ const getPluginContent = async ({plugin, reporter}) => {
     });
 };
 
-const fetchPluginData = async ({createNode, reporter, firstReleases, labelToCategory}) => {
+const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
     const sectionActivity = reporter.activityTimer('fetch plugins info');
     sectionActivity.start();
     const promises = [];
@@ -128,7 +128,6 @@ const fetchPluginData = async ({createNode, reporter, firstReleases, labelToCate
                     securityWarnings: updateData.warnings.filter(p => p.name == pluginName)
                         .map(w => checkActive(w, pluginUC)),
                     dependencies: getImpliedDependenciesAndTitles(pluginUC, detachedPlugins, updateData),
-                    categories: Array.from(new Set(pluginUC.labels.map(label => labelToCategory[label]))),
                     firstRelease: firstReleases[pluginName].toISOString(),
                     id: pluginName,
                     hasPipelineSteps: pipelinePluginIds.includes(pluginName),
@@ -249,13 +248,10 @@ const fetchSuspendedPlugins = async ({updateData, names, createNode}) => {
     await Promise.all(suspendedPromises);
 };
 
-const processCategoryData = async ({createNode, reporter, labelToCategory}) => {
+const processCategoryData = async ({createNode, reporter}) => {
     const sectionActivity = reporter.activityTimer('process categories');
     sectionActivity.start();
     for (const category of categoryList) {
-        for (const label of category.labels) {
-            labelToCategory[label] = category.id;
-        }
         createNode({
             ...category,
             id: category.id.trim(),

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -7,6 +7,7 @@ const URL = require('url');
 const axiosRetry = require('axios-retry');
 const dateFNs = require('date-fns');
 const {parseStringPromise} = require('xml2js');
+const categoryList = require('./categories.json');
 
 axiosRetry(axios, {retries: 3});
 
@@ -95,7 +96,9 @@ const getPluginContent = async ({plugin, reporter}) => {
     });
 };
 
-const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
+const unique = (value, index, self) => self.indexOf(value) === index;
+
+const fetchPluginData = async ({createNode, reporter, firstReleases, labelToCategory}) => {
     const sectionActivity = reporter.activityTimer('fetch plugins info');
     sectionActivity.start();
     const promises = [];
@@ -107,6 +110,10 @@ const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
     const bomDependencies = await fetchBomDependencies(reporter);
     const updateUrl = 'https://updates.jenkins.io/update-center.actual.json';
     const updateData = await requestGET({url: updateUrl, reporter});
+    const detachedUrl = 'https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt';
+    const detachedPluginsData = await requestGET({url: detachedUrl, reporter});
+    const detachedPlugins = detachedPluginsData.split('\n')
+        .filter(row => row.length && !row.startsWith('#')).map(row => row.split(' '));
     do {
         const url = `https://plugins.jenkins.io/api/plugins/?limit=100&page=${page}`;
         pluginsContainer = await requestGET({url, reporter});
@@ -122,8 +129,8 @@ const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
                     wiki: pluginData.wiki,
                     securityWarnings: updateData.warnings.filter(p => p.name == pluginName)
                         .map(w => checkActive(w, pluginUC)),
-                    dependencies: pluginData.dependencies,
-                    categories: pluginData.categories,
+                    dependencies: pluginUC.dependencies.concat(getImpliedDependencies(plugin, detachedPlugins, updateData)),
+                    categories: pluginUC.labels.map(label => labelToCategory[label]).filter(unique),
                     firstRelease: firstReleases[pluginName].toISOString(),
                     id: pluginName,
                     hasPipelineSteps: pipelinePluginIds.includes(pluginName),
@@ -182,6 +189,27 @@ const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
     sectionActivity.end();
 };
 
+const getImpliedDependencies= (plugin, detachedPlugins, updateData) => {
+    const implied = [];
+    for (const detached of detachedPlugins) {
+        const [detachedPlugin, detachedCore, detachedVersion] = detached;
+        if (versionToNumber(detachedCore) > versionToNumber(plugin.requiredCore)) {
+            const title = updateData.plugins[detachedPlugin].title;
+            implied.push({name: detachedPlugin,
+                version: detachedVersion,
+                title: title,
+                implied: true,
+                optional: false});
+        }
+    }
+    return implied;
+};
+
+const versionToNumber = (version) => {
+    const [major, minor] = version.split('.').map(n => parseInt(n));
+    return major * 1E5 + minor;
+};
+
 const checkActive = (warning, plugin) => {
     warning.active = !!warning.versions.find(version => plugin.version.match(`^${version.pattern}$`));
     return warning;
@@ -219,13 +247,13 @@ const fetchSuspendedPlugins = async ({updateData, names, createNode}) => {
     await Promise.all(suspendedPromises);
 };
 
-const fetchCategoryData = async ({createNode, reporter}) => {
-    const sectionActivity = reporter.activityTimer('fetch categories info');
+const processCategoryData = async ({createNode, reporter, labelToCategory}) => {
+    const sectionActivity = reporter.activityTimer('process categories');
     sectionActivity.start();
-    const url = 'https://plugins.jenkins.io/api/categories/?limit=100';
-    const categoriesContainer = await requestGET({url, reporter});
-
-    for (const category of categoriesContainer.categories) {
+    for (const category of categoryList) {
+        for (const label of category.labels) {
+            labelToCategory[label] = category.id;
+        }
         createNode({
             ...category,
             id: category.id.trim(),
@@ -246,23 +274,27 @@ const fetchCategoryData = async ({createNode, reporter}) => {
 const fetchLabelData = async ({createNode, reporter}) => {
     const sectionActivity = reporter.activityTimer('fetch labels info');
     sectionActivity.start();
-    const url = 'https://plugins.jenkins.io/api/labels/?limit=100';
-    const labelsContainer = await requestGET({url, reporter});
-
-    for (const label of labelsContainer.labels) {
-        createNode({
-            ...label,
-            id: label.id.trim(),
-            parent: null,
-            children: [],
-            internal: {
-                type: 'JenkinsPluginLabel',
-                contentDigest: crypto
-                    .createHash('md5')
-                    .update(`label${label.name}`)
-                    .digest('hex')
-            }
-        });
+    const url = 'https://raw.githubusercontent.com/jenkinsci/jenkins/master/core/src/main/resources/hudson/model/Messages.properties';
+    const messages = await requestGET({url, reporter});
+    const keyPrefix = 'UpdateCenter.PluginCategory';
+    for (const line of messages.split('\n')) {
+        const [key, value] = line.split('=', 2).map(s => s.trim());
+        const labelId = key.substring(keyPrefix.length + 1);
+        if (key.startsWith(keyPrefix)) {
+            createNode({
+                title: value,
+                id: labelId,
+                parent: null,
+                children: [],
+                internal: {
+                    type: 'JenkinsPluginLabel',
+                    contentDigest: crypto
+                        .createHash('md5')
+                        .update(`label${labelId}`)
+                        .digest('hex')
+                }
+            });
+        }
     }
     sectionActivity.end();
 };
@@ -301,13 +333,13 @@ const fetchPluginVersions = async ({createNode, reporter, firstReleases}) => {
     for (const pluginVersions of Object.values(json.plugins)) {
         for (const data of Object.values(pluginVersions)) {
             /*
-            buildDate	"May 13, 2020"
-            dependencies	[…]
-            name	"42crunch-security-audit"
-            requiredCore	"2.164.3"
-            sha1	"nQl64SC4dvbFE0Kbwkdqe2C0hG8="
-            sha256	"rMxlZQqnAofpD1/vNosqcPgghuhXKzRrpLuLHV8XUQ8="
-            url	"https://updates.jenkins.io/download/plugins/42crunch-security-audit/2.1/42crunch-security-audit.hpi"
+            buildDate    "May 13, 2020"
+            dependencies    […]
+            name    "42crunch-security-audit"
+            requiredCore    "2.164.3"
+            sha1    "nQl64SC4dvbFE0Kbwkdqe2C0hG8="
+            sha256    "rMxlZQqnAofpD1/vNosqcPgghuhXKzRrpLuLHV8XUQ8="
+            url    "https://updates.jenkins.io/download/plugins/42crunch-security-audit/2.1/42crunch-security-audit.hpi"
             version 2.1
             */
             const date = dateFNs.parse(data.buildDate, 'MMMM d, yyyy', new Date(0));
@@ -336,7 +368,7 @@ const fetchPluginVersions = async ({createNode, reporter, firstReleases}) => {
 module.exports = {
     fetchSiteInfo,
     fetchLabelData,
-    fetchCategoryData,
+    processCategoryData,
     fetchPluginData,
     fetchPluginVersions,
     getPluginContent,

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -9,6 +9,8 @@ nock.disableNetConnect();
 
 process.env.GET_CONTENT = true;
 
+const readText = async (fileName) => {const buffer = await fs.promises.readFile(path.join(__dirname, '__mocks__', fileName)); return buffer.toString();};
+
 describe('Utils', () => {
     let _reporter;
     afterEach(() => {
@@ -28,34 +30,21 @@ describe('Utils', () => {
     it('Get plugin data for a wiki based plugin', async () => {
         nock('https://updates.jenkins.io')
             .get('/update-center.actual.json')
-            .reply(200, {deprecations: [], warnings: [], plugins: {
-                'ios-device-connector': {'buildDate': 'Oct 10, 2012','defaultBranch': 'master','dependencies': [],
-                    'developers': [],'excerpt': 'Talks to iOS devices connected to slaves and do stuff.',
-                    'gav': 'org.jenkins-ci.plugins:ios-device-connector:1.2',
-                    'issueTrackers': [{'reportUrl': 'https://www.jenkins.io/participate/report-issue/redirect/#17020',
-                        'type': 'jira','viewUrl': 'https://issues.jenkins.io/issues/?jql=component=17020'}],
-                    'labels': ['builder','ios'],'name': 'ios-device-connector','popularity': 275,
-                    'previousTimestamp': '2012-10-08T20:04:36.00Z','previousVersion': '1.1',
-                    'releaseTimestamp': '2012-10-10T17:27:42.00Z','requiredCore': '1.466',
-                    'scm': 'https://github.com/jenkinsci/ios-device-connector-plugin',
-                    'sha1': 'B2z2wTyA8l5uwz9HqD+xhG9Hjns=',
-                    'sha256': 'Tray3+tyfE6xoTu1Rge9+INkcj5y7Bgw7nPm//saiYw=','size': 1548862,
-                    'title': 'iOS Device connector','url': 'https://updates.jenkins.io/download/plugins/ios-device-connector/1.2/ios-device-connector.hpi',
-                    'version': '1.2','wiki': 'https://plugins.jenkins.io/ios-device-connector'}
-            }});
+            .reply(200, JSON.parse(await readText('update-center.actual.json')));
         nock('https://www.jenkins.io')
             .get('/doc/pipeline/steps/contents.json')
             .reply(200, []);
         nock('https://raw.githubusercontent.com:443')
             .get('/jenkinsci/bom/master/bom-latest/pom.xml')
             .reply(200, '');
+        nock('https://raw.githubusercontent.com:443')
+            .get('/jenkinsci/jenkins/master/core/src/main/resources/jenkins/split-plugins.txt')
+            .reply(200, await readText('split-plugins.txt'));
         nock('https://plugins.jenkins.io')
             .get('/api/plugins/?limit=100&page=1')
             .reply(200, {
                 'plugins': [
-                    JSON.parse(
-                        await fs.promises.readFile(path.join(__dirname, '__mocks__', 'plugins.jenkins.io.api.plugin.ios-device-connector.json')).then(d => d.toString())
-                    )
+                    JSON.parse(await readText('plugins.jenkins.io.api.plugin.ios-device-connector.json'))
                 ],
                 'page': 1,
                 'pages': 1,
@@ -68,7 +57,8 @@ describe('Utils', () => {
 
         const createNode = jest.fn().mockResolvedValue();
         const firstReleases = {'ios-device-connector': new Date(0)};
-        await utils.fetchPluginData({createNode, reporter: _reporter, firstReleases});
+        const labelToCategory = {'ios': 'languagesPlatforms', 'builder': 'buildManagement'};
+        await utils.fetchPluginData({createNode, reporter: _reporter, firstReleases, labelToCategory});
         expect(createNode.mock.calls[0][0]).toMatchSnapshot();
     });
 });

--- a/src/commons/helper.js
+++ b/src/commons/helper.js
@@ -24,8 +24,8 @@ export function cleanTitle(title) {
         .replace(' plugin', '')
         .replace(' Plug-in', '')
         .replace(' plug-in', '')
-        .replace(' for Jenkins','')
-        .replace('Hudson ','');
+        .replace(' for Jenkins', '')
+        .replace('Hudson ', '');
 }
 
 export const defaultPluginSiteTitle = 'Jenkins Plugins';

--- a/src/components/FiltersHooks.jsx
+++ b/src/components/FiltersHooks.jsx
@@ -37,7 +37,7 @@ function useFilterHooks({doSearch, setResults}) {
 
     ['sort', 'categories', 'labels', 'view', 'page'].forEach(key => {
         ret[`set${ucFirst(key)}`] = (val) => {
-            const newData = {...data,[key]: val};
+            const newData = {...data, [key]: val};
             navigate(`/ui/search?${querystring.stringify({...newData, query})}`);
             ret.setData(newData);
             doSearch(newData, setResults);

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useStaticQuery, graphql,Link} from 'gatsby';
+import {useStaticQuery, graphql, Link} from 'gatsby';
 
 import PluginLink from './PluginLink';
 

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -2,18 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {cleanTitle} from '../commons/helper';
 
-const COLORS = ['#6D6B6D','#DCD9D8','#D33833','#335061','#81B0C4','#709aaa','#000'];
+const COLORS = ['#6D6B6D', '#DCD9D8', '#D33833', '#335061', '#81B0C4', '#709aaa', '#000'];
 
 function Icon({title}) {
     title = cleanTitle(title);
     // pick color based on chars in the name to make semi-random, but fixed color per-plugin
     const color = COLORS[(title.length % 7)];
-    const firstLetter = title.substring(0,1).toUpperCase();
+    const firstLetter = title.substring(0, 1).toUpperCase();
     const firstSpace = title.indexOf(' ') + 1;
     const nextIndex = firstSpace === 0 ? 1 : firstSpace;
     const nextLetter = title.substring(nextIndex, nextIndex + 1);
     return (
-        <i className="i" style={{background: color,}}>
+        <i className="i" style={{background: color}}>
             <span className="first">{firstLetter}</span>
             <span className="next">{nextLetter}</span>
         </i>

--- a/src/components/SiteVersion.jsx
+++ b/src/components/SiteVersion.jsx
@@ -25,7 +25,7 @@ function SiteVersion() {
     return (
         <p>
             {'UI '}
-            <a href={`https://github.com/jenkins-infra/plugin-site/commit/${pluginSiteVersion}`}>{pluginSiteVersion.substr(0,7)}</a>
+            <a href={`https://github.com/jenkins-infra/plugin-site/commit/${pluginSiteVersion}`}>{pluginSiteVersion.substr(0, 7)}</a>
             {' / API '}
             <a href={`https://github.com/jenkins-infra/plugin-site-api/commit/${pluginSiteApiVersion}`}>{pluginSiteApiVersion.substr(0, 7)}</a>
             <br />

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -49,7 +49,6 @@ export const PluginFragment = graphql`
     }
     firstRelease
     excerpt
-    categories
     buildDate
     dependencies {
       implied

--- a/src/templates/search.jsx
+++ b/src/templates/search.jsx
@@ -1,3 +1,4 @@
+
 // import {graphql} from 'gatsby';
 import React from 'react';
 import querystring from 'querystring';
@@ -76,6 +77,7 @@ const doSearch = (data, setResults) => {
             })
             .then(response => response.json())
             .then(data => {
+                data.plugins.forEach(p => p.developers = p.maintainers);
                 data.pages = data.pages + 1;
                 return data;
             })

--- a/src/templates/search.jsx
+++ b/src/templates/search.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import querystring from 'querystring';
 import PropTypes from 'prop-types';
-import {navigate} from 'gatsby';
+import {navigate,useStaticQuery, graphql} from 'gatsby';
 import fetch from 'isomorphic-fetch';
 import algoliasearch from 'algoliasearch/lite';
 
@@ -18,16 +18,19 @@ import Filters from '../components/Filters';
 import ActiveFilters from '../components/ActiveFilters';
 import SearchByAlgolia from '../components/SearchByAlgolia';
 
+
 const useAlgolia = process.env.GATSBY_ALGOLIA_APP_ID && process.env.GATSBY_ALGOLIA_SEARCH_KEY;
 
-const doSearch = (data, setResults) => {
+const doSearch = (data, setResults, categoryList) => {
     const {query, sort} = data;
     let {categories, labels, page} = data;
     if (!Array.isArray(categories)) { categories = [categories]; }
     categories = categories.filter(Boolean);
     if (!Array.isArray(labels)) { labels = [labels]; }
     labels = labels.filter(Boolean);
-
+    for (const categoryId of categories) {
+        categoryList.edges.filter(e => e.node.id == categoryId).forEach(e => labels.push(...e.node.labels));
+    }
     setResults(null);
     if (useAlgolia) {
         const searchClient = algoliasearch(
@@ -36,9 +39,6 @@ const doSearch = (data, setResults) => {
         );
         const index = searchClient.initIndex('Plugins');
         const filters = [];
-        if (categories && categories.length) {
-            filters.push(`(${categories.map(c => `categories:${c}`).join(' OR ')})`);
-        }
         if (labels && labels.length) {
             filters.push(`(${labels.map(l => `labels:${l}`).join(' OR ')})`);
         }
@@ -64,7 +64,7 @@ const doSearch = (data, setResults) => {
             });
         });
     } else {
-        const params = querystring.stringify({categories, labels, page, q: query, sort});
+        const params = querystring.stringify({labels, page, q: query, sort});
         const url = `${process.env.GATSBY_API_URL || '/api'}/plugins?${params}`;
         fetch(url, {mode: 'cors'})
             .then((response) => {
@@ -108,6 +108,20 @@ function SearchPage({location}) {
         doSearch(newData, setResults);
     };
 
+    const categoryList = useStaticQuery(graphql`
+        query {
+            categories: allJenkinsPluginCategory {
+                edges {
+                    node {
+                        id
+                        labels
+                        title
+                    }
+                }
+            }
+        }
+    `).categories;
+
     const searchPage = 'templates/search.jsx';
 
     React.useEffect(() => {
@@ -116,7 +130,7 @@ function SearchPage({location}) {
         parsed.query = parsed.query || '';
         setData(parsed);
         setQuery(parsed.query);
-        doSearch(parsed, setResults);
+        doSearch(parsed, setResults, categoryList);
     }, []);
 
     return (

--- a/src/templates/search.jsx
+++ b/src/templates/search.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import querystring from 'querystring';
 import PropTypes from 'prop-types';
-import {navigate,useStaticQuery, graphql} from 'gatsby';
+import {navigate, useStaticQuery, graphql} from 'gatsby';
 import fetch from 'isomorphic-fetch';
 import algoliasearch from 'algoliasearch/lite';
 

--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -43,7 +43,7 @@ function pluginQueries() {
         synonyms: [
             {
                 type: 'synonym',
-                synonyms: ['perforce','p4'],
+                synonyms: ['perforce', 'p4'],
                 objectID: 'syn-1617250859718-18'
             }
         ],

--- a/src/utils/algolia-queries.js
+++ b/src/utils/algolia-queries.js
@@ -9,7 +9,6 @@ function pluginQueries() {
               content
             }
             name
-            categories
             excerpt
             labels
             stats {
@@ -70,7 +69,6 @@ function pluginQueries() {
                 'desc(stats.currentInstalls)'
             ],
             attributesForFaceting: [
-                'categories',
                 'labels'
             ],
             attributesToIndex: [

--- a/utils.js
+++ b/utils.js
@@ -123,7 +123,7 @@ async function makeReactLayout() {
         } else if (node.type === 'comment') {
             return;
         } else if (node.type === 'text') {
-            const text = node.data.replace('\u00A0','&nbsp;');
+            const text = node.data.replace('\u00A0', '&nbsp;');
             jsxLines.push(`${prefix}${text}`);
         } else if (node.children && node.children.length) {
             jsxLines.push(`${prefix}<${node.name} ${attrs}>`);


### PR DESCRIPTION
Reduce the dependency on `plugin-site-api`
* move categories here as a static file (currently a static file in `plugin-site-api`)
* get detachments directly from Jenkins source via GitHub (currently using GitHub also in `plugin-site-api`)
* get labels directly from Jenkins source via GitHub (currently a static file in `plugin-site-api`, uses slightly differerent wording)

