### PR TITLE
Fix GitHub URLs for submodules

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -123,6 +123,7 @@ const fetchPluginData = async ({createNode, reporter, firstReleases}) => {
             names.push(pluginName);
             const pluginUC = updateData.plugins[pluginName];
             pluginUC.developers.forEach(maint => {maint.id = maint.developerId, delete(maint.developerId);});
+            pluginUC.scm = fixGitHubUrl(pluginUC.scm, pluginUC.defaultBranch || 'master');
             promises.push(getPluginContent({plugin, reporter}).then(pluginData => {
                 const p = createNode({
                     ...pluginUC,
@@ -217,6 +218,14 @@ const versionToNumber = (version) => {
 const checkActive = (warning, plugin) => {
     warning.active = !!warning.versions.find(version => plugin.version.match(`^(${version.pattern})$`));
     return warning;
+};
+
+const fixGitHubUrl = (url, defaultBranch) => {
+    const match = url && url.match(/^(https?:\/\/github.com\/[^/]+\/[^/]+)\/(.+)$/);
+    if (match && defaultBranch && !match[2].startsWith('tree/')) {
+        return `${match[1]}/tree/${defaultBranch}/${match[2]}`;
+    }
+    return url;
 };
 
 const fetchBomDependencies = async (reporter) => {
@@ -372,6 +381,7 @@ module.exports = {
     processCategoryData,
     fetchPluginData,
     fetchPluginVersions,
+    fixGitHubUrl,
     getPluginContent,
     requestGET
 };

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -27,6 +27,18 @@ describe('Utils', () => {
             }
         };
     });
+    it('Fix GitHub URL: submodule gets expanded', () => {
+        expect(utils.fixGitHubUrl('https://github.com/jenkinsci/blueocean-plugin/blueocean-bitbucket-pipeline', 'master'))
+            .toBe('https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-bitbucket-pipeline');
+    });
+    it('Fix GitHub URL: expanded stays expanded', () => {
+        expect(utils.fixGitHubUrl('https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-bitbucket-pipeline', 'master'))
+            .toBe('https://github.com/jenkinsci/blueocean-plugin/tree/master/blueocean-bitbucket-pipeline');
+    });
+    it('Fix GitHub URL: no submodule, keep short', () => {
+        expect(utils.fixGitHubUrl('https://github.com/jenkinsci/junit-plugin', ''))
+            .toBe('https://github.com/jenkinsci/junit-plugin');
+    });
     it('Get plugin data for a wiki based plugin', async () => {
         nock('https://updates.jenkins.io')
             .get('/update-center.actual.json')


### PR DESCRIPTION
Fixes #520

If GitHub URL is in the form github.com/org/repo/path, we should point to github.com/org/repo/tree/defaultBranch/path . Probably makes sense to normalize here instead of fixing in plugins because it's unclear what URLs should be in the POM of a plugin. Also it's not just the ~20 BO plugins, but also ~10 other plugins including https://plugins.jenkins.io/structs/ 

