### PR TITLE
add @zbynek  to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenkins-infra/plugin-site
+* @jenkins-infra/plugin-site @zbynek


### PR DESCRIPTION
As a non org member i can't add @zbynek to the plugin site team, so hoping this will work in the mean time