### PR TITLE
Fix #804 - No report url failing the build

### DIFF
--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -47,7 +47,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
 
     return (
         <Layout id="pluginPage" reportProblemRelativeSourcePath={pluginPage} reportProblemTitle={plugin.title}
-            reportProblemUrl={plugin.issueTrackers && plugin.issueTrackers[0] ? plugin.issueTrackers[0].reportUrl : `/${plugin.name}`}>
+            reportProblemUrl={plugin?.issueTrackers?.find(tracker => tracker.reportUrl)?.reportUrl || `/${plugin.name}`}>
             <SEO title={cleanTitle(plugin.title)} description={plugin.excerpt} pathname={`/${plugin.id}`}/>
             <div className="title-wrapper">
                 <h1 className="title">


### PR DESCRIPTION
Related to issue #804

Summary of this pull request: Looks like plugins can disable one or more reporting urls. Loop through all of them, find the first that has it enabled, else generic reporting url.

note, using the "new" ? operator since our babel setup lets us use it, and it makes this case so much easier.
