### PR TITLE
Refactor createNode generation

### DIFF
--- a/loadershim.js
+++ b/loadershim.js
@@ -1,3 +1,5 @@
+delete process.env.JENKINS_IO_API_URL;
+
 global.___loader = {
     enqueue: jest.fn(),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "github-syntax-light": "^0.5.0",
         "isomorphic-fetch": "^3.0.0",
         "moment": "^2.29.1",
+        "p-queue": "^6.6.2",
         "postcss-calc": "^8.0.0",
         "postcss-css-variables": "^0.18.0",
         "postcss-extend": "^1.0.5",
@@ -27749,6 +27750,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-reduce": {
@@ -61090,6 +61117,25 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-3.1.0.tgz",
       "integrity": "sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw=="
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
+      }
     },
     "p-reduce": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "github-syntax-light": "^0.5.0",
     "isomorphic-fetch": "^3.0.0",
     "moment": "^2.29.1",
+    "p-queue": "^6.6.2",
     "postcss-calc": "^8.0.0",
     "postcss-css-variables": "^0.18.0",
     "postcss-extend": "^1.0.5",

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -120,7 +120,7 @@ Object {
   "hasPipelineSteps": false,
   "id": "ios-device-connector",
   "internal": Object {
-    "contentDigest": "7da41342fb756c851d4b5a9b6b6f9f3e",
+    "contentDigest": "0d06372538374458b993554af9540915",
     "type": "JenkinsPlugin",
   },
   "issueTrackers": Array [

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
@@ -8,21 +8,19 @@ const {
 } = require('./utils');
 
 exports.sourceNodes = async (
-    {actions, reporter},
+    {actions: {createNode}, reporter, createContentDigest, createNodeId},
     { /* options */ } // eslint-disable-line no-empty-pattern
 ) => {
-    const {createNode} = actions;
-
     try {
         const firstReleases = {};
         const stats = {};
         await Promise.all([
             fetchStats({reporter, stats}),
-            fetchSiteInfo({createNode, reporter}),
-            processCategoryData({createNode, reporter}),
-            fetchLabelData({createNode, reporter}),
-            fetchPluginVersions({createNode, reporter, firstReleases}),
-        ]).then(() => fetchPluginData({createNode, reporter, firstReleases, stats}));
+            fetchSiteInfo({createNode, createContentDigest, createNodeId, reporter}),
+            processCategoryData({createNode, createContentDigest, createNodeId, reporter}),
+            fetchLabelData({createNode, createContentDigest, createNodeId, reporter}),
+            fetchPluginVersions({createNode, createContentDigest, createNodeId, reporter, firstReleases}),
+        ]).then(() => fetchPluginData({createNode, createContentDigest, createNodeId, reporter, firstReleases, stats}));
     } catch (err) {
         reporter.panic(
             `gatsby-source-jenkinsplugin: Failed to parse API call -  ${err.stack || err}`

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -6,8 +6,12 @@ const {execSync} = require('child_process');
 const URL = require('url');
 const axiosRetry = require('axios-retry');
 const dateFNs = require('date-fns');
+const {default: PQueue} = require('p-queue'); // NOTE - pinned at p-queue@6.6.2 because 7 requires whole project to be esm
 const {parseStringPromise} = require('xml2js');
 const categoryList = require('./categories.json');
+
+
+const API_URL = process.env.JENKINS_IO_API_URL || 'https://plugins.jenkins.io/api';
 
 axiosRetry(axios, {retries: 3});
 
@@ -60,7 +64,6 @@ const shouldFetchPluginContent = (id) => {
     return true;
 };
 
-
 const pluginWikiUrlRe = /^https?:\/\/wiki.jenkins(?:-ci.org|.io)\/display\/(?:jenkins|hudson)\/([^/]*)\/?$/i;
 const getPluginContent = async ({wiki, pluginName, reporter}) => {
     if (!shouldFetchPluginContent(pluginName)) {
@@ -91,10 +94,69 @@ const getPluginContent = async ({wiki, pluginName, reporter}) => {
     });
 };
 
-const fetchPluginData = async ({createNode, reporter, firstReleases, stats}) => {
+const processPlugin = ({createNode, names, stats, updateData, detachedPlugins, documentation, bomDependencies, pipelinePluginIds, firstReleases, createContentDigest, createNodeId, reporter, plugin}) => {
+    return async function () {
+        const pluginName = plugin.name.trim();
+        names.push(pluginName);
+        const developers = plugin.developers || [];
+        developers.forEach(maint => {maint.id = maint.developerId, delete(maint.developerId);});
+        plugin.scm = fixGitHubUrl(plugin.scm, plugin.defaultBranch || 'master');
+        const pluginStats = stats[pluginName] || {installations: null};
+        pluginStats.trend = computeTrend(plugin, stats, updateData.plugins);
+        const allDependencies = getImpliedDependenciesAndTitles(plugin, detachedPlugins, updateData);
+        const wiki = await getPluginContent({wiki: documentation[pluginName] || {}, pluginName, reporter});
+
+        const pluginNode = {
+            ...plugin,
+            id: createNodeId(plugin.name.trim()),
+            stats: pluginStats,
+            wiki: wiki,
+            securityWarnings: updateData.warnings.filter(p => p.name == pluginName)
+                .map(w => checkActive(w, plugin)),
+            dependencies: allDependencies,
+            firstRelease: firstReleases[pluginName] && firstReleases[pluginName].toISOString(),
+            hasPipelineSteps: pipelinePluginIds.includes(pluginName),
+            hasBomEntry: !!bomDependencies.find(artifactId => plugin.gav.includes(`:${artifactId}:`)),
+            parent: null,
+            children: [],
+            internal: {
+                type: 'JenkinsPlugin',
+            }
+        };
+        pluginNode.internal.contentDigest = createContentDigest(pluginNode);
+        createNode(pluginNode);
+
+        for (const maintainer of developers) {
+            const developerNode = {
+                ...maintainer,
+                id: createNodeId(maintainer.id),
+                internal: {
+                    type: 'JenkinsDeveloper',
+                    contentDigest: crypto.createHash('md5').update(maintainer.id).digest('hex')
+                }
+            };
+            developerNode.internal.contentDigest = createContentDigest(developerNode);
+            createNode(developerNode);
+        }
+        for (const dependency of allDependencies) {
+            const dependencyNode = {
+                ...dependency,
+                dependentTitle: plugin.title,
+                dependentName: plugin.name,
+                id: createNodeId(`${pluginName}:${dependency.name.trim()}`),
+                internal: {
+                    type: 'JenkinsPluginDependency',
+                }
+            };
+            dependencyNode.internal.contentDigest = createContentDigest(dependencyNode);
+            createNode(dependencyNode);
+        }
+    };
+};
+
+const fetchPluginData = async ({createNode, createContentDigest, createNodeId, reporter, firstReleases, stats}) => {
     const sectionActivity = reporter.activityTimer('fetch plugins info');
     sectionActivity.start();
-    const promises = [];
     const names = [];
     const pipelinePluginsUrl = 'https://www.jenkins.io/doc/pipeline/steps/contents.json';
     const pipelinePluginIds = await requestGET({url: pipelinePluginsUrl, reporter});
@@ -114,74 +176,25 @@ const fetchPluginData = async ({createNode, reporter, firstReleases, stats}) => 
     }
     const documentationListUrl = 'https://updates.jenkins.io/current/plugin-documentation-urls.json';
     const documentation = await requestGET({url: documentationListUrl, reporter});
-    for (const plugin of Object.values(updateData.plugins)) {
-        const pluginName = plugin.name.trim();
-        names.push(pluginName);
-        const developers = plugin.developers || [];
-        developers.forEach(maint => {maint.id = maint.developerId, delete(maint.developerId);});
-        plugin.scm = fixGitHubUrl(plugin.scm, plugin.defaultBranch || 'master');
-        const pluginStats = stats[pluginName] || {installations: null};
-        pluginStats.trend = computeTrend(plugin, stats, updateData.plugins);
-        const allDependencies = getImpliedDependenciesAndTitles(plugin, detachedPlugins, updateData);
-        promises.push(getPluginContent({wiki: documentation[pluginName] || {}, pluginName, reporter}).then(wiki => {
-            const p = createNode({
-                ...plugin,
-                stats: pluginStats,
-                wiki: wiki,
-                securityWarnings: updateData.warnings.filter(p => p.name == pluginName)
-                    .map(w => checkActive(w, plugin)),
-                dependencies: allDependencies,
-                firstRelease: firstReleases[pluginName] && firstReleases[pluginName].toISOString(),
-                id: pluginName,
-                hasPipelineSteps: pipelinePluginIds.includes(pluginName),
-                hasBomEntry: !!bomDependencies.find(artifactId => plugin.gav.includes(`:${artifactId}:`)),
-                parent: null,
-                children: [],
-                internal: {
-                    type: 'JenkinsPlugin',
-                    contentDigest: crypto.createHash('md5').update(`plugin${pluginName}`).digest('hex')
-                }
-            });
-            if (!p || !p.then) {
-                if (process.env.GATSBY_SENTRY_DSN) {
-                    const Sentry = require('@sentry/node');
-                    Sentry.init({
-                        dsn: process.env.GATSBY_SENTRY_DSN
-                    });
-                    Sentry.captureMessage(new Error(`Error creatingNode for plugin: ${pluginName}`), {extra: {pluginData: plugin, p: p}});
-                }
-                return new Error('no promise returned');
-            }
-            p.then(() => {
-                return Promise.all(developers.map(maintainer => {
-                    return createNode({
-                        ...maintainer,
-                        internal: {
-                            type: 'JenkinsDeveloper',
-                            contentDigest: crypto.createHash('md5').update(maintainer.id).digest('hex')
-                        }
-                    });
-                }));
-            });
-            return p.then(() => {
-                return Promise.all(allDependencies.map(dependency => {
-                    const mergedId = `${pluginName}:${dependency.name.trim()}`;
-                    return createNode({
-                        ...dependency,
-                        dependentTitle: plugin.title,
-                        dependentName: plugin.name,
-                        id: mergedId,
-                        internal: {
-                            type: 'JenkinsPluginDependency',
-                            contentDigest: crypto.createHash('md5').update(`dep${mergedId}`).digest('hex')
-                        }
-                    });
-                }));
-            });
-        }));
-    }
 
-    await Promise.all(promises);
+    const queue = new PQueue({concurrency: 100, autoStart: true});
+    Object.values(updateData.plugins).forEach(plugin => queue.add(processPlugin({
+        plugin,
+        names,
+        stats,
+        updateData,
+        detachedPlugins,
+        documentation,
+        bomDependencies,
+        pipelinePluginIds,
+        firstReleases,
+        createNode,
+        createContentDigest,
+        createNodeId,
+        reporter
+    })));
+    await queue.onIdle();
+
     await fetchSuspendedPlugins({updateData, names, createNode});
     sectionActivity.end();
 };
@@ -338,7 +351,7 @@ const fetchLabelData = async ({createNode, reporter}) => {
 const fetchSiteInfo = async ({createNode, reporter}) => {
     const sectionActivity = reporter.activityTimer('fetch plugin api info');
     sectionActivity.start();
-    const url = 'https://plugins.jenkins.io/api/info';
+    const url = `${API_URL}/info`;
     const info = await requestGET({url, reporter});
 
     createNode({

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -63,6 +63,8 @@ describe('Utils', () => {
             .replyWithFile(200, path.join(__dirname, '__mocks__', 'wiki.jenkins.io.io-device-connector-plugin.json'), {'Content-Type': 'application/json'});
 
         const createNode = jest.fn().mockResolvedValue();
+        const createContentDigest = require('gatsby-core-utils').createContentDigest;
+        const createNodeId = jest.fn(key => key);
         const firstReleases = {'ios-device-connector': new Date(0)};
         const labelToCategory = {'ios': 'languagesPlatforms', 'builder': 'buildManagement'};
         const stats = {
@@ -82,7 +84,7 @@ describe('Utils', () => {
                 {'timestamp': 1619841600000, 'total': 275},
                 {'timestamp': 1622520000000, 'total': 269}]}
         };
-        await utils.fetchPluginData({createNode, reporter: _reporter, firstReleases, labelToCategory, stats});
+        await utils.fetchPluginData({createNode, createNodeId, createContentDigest, reporter: _reporter, firstReleases, labelToCategory, stats});
         expect(createNode.mock.calls[0][0]).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
* Allow overriding api url (So i could test removing wiki support, incoming PR)
* Setup a 100 queue to fetch content
  * previous was grabbing everything at once and node was crashing/running out of resources/etc
  * It'll never be fetching more than 100 at a time, when one finishes, new one starts
* Remove promises for createNode https://github.com/gatsbyjs/gatsby/issues/30578#issue-845213551
* Use built in functions to create unique ids and content digest so partial updates might work
