### PR TITLE
Fix html rendering for new markdown wiki types

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -8,7 +8,7 @@ Array [
     "internal": Object {
       "content": "MISSING",
       "contentDigest": "10d1208b485425756fcc932229386b02",
-      "mediaType": "text/plain",
+      "mediaType": "text/pluginhtml",
       "type": "JenkinsPluginWiki",
     },
     "name": "ios-device-connector",

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -86,10 +86,10 @@ const getPluginContent = async ({wiki, pluginName, reporter, createNode, createC
             }
         }
         const data = await requestGET({reporter, url: `https://plugins.jenkins.io/api/plugin/${pluginName}`});
-        return createWikiNode('text/html', wiki.url, data.wiki.content);
+        return createWikiNode('text/pluginhtml', wiki.url, data.wiki.content);
     } catch (err) {
         reporter.error(`error fetching ${pluginName}`, err);
-        return createWikiNode('text/plain', wiki.url, 'MISSING');
+        return createWikiNode('text/pluginhtml', wiki.url, 'MISSING');
     }
 };
 

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -9,8 +9,13 @@ export const PluginFragment = graphql`
     url
     version
     wiki {
-      html
-      url
+        childMarkdownRemark {
+            html
+        }
+        childJenkinsPluginHtml {
+            html
+        }
+        url
     }
     stats {
       currentInstalls

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -42,8 +42,11 @@ function getDefaultTab() {
 }
 
 const PluginWikiContent = ({wiki}) => {
-    if (wiki?.html) {
-        return <div className="content" dangerouslySetInnerHTML={{__html: wiki.html}} />;
+    if (wiki?.childMarkdownRemark) {
+        return <div className="content" dangerouslySetInnerHTML={{__html: wiki.childMarkdownRemark.html}} />;
+    }
+    if (wiki?.childJenkinsPluginHtml) {
+        return <div className="content" dangerouslySetInnerHTML={{__html: wiki.childJenkinsPluginHtml.html}} />;
     }
     return (<div className="content">
         Documentation for this plugin is here:
@@ -54,7 +57,12 @@ const PluginWikiContent = ({wiki}) => {
 PluginWikiContent.displayName = 'PluginWikiContent';
 PluginWikiContent.propTypes = {
     wiki: PropTypes.shape({
-        html: PropTypes.string,
+        childMarkdownRemark: PropTypes.shape({
+            html: PropTypes.string,
+        }),
+        childJenkinsPluginHtml: PropTypes.shape({
+            html: PropTypes.string,
+        }),
         url: PropTypes.string.isRequired
     }).isRequired,
 };


### PR DESCRIPTION
I made it more complicated than it needed to be. I was excited by the
field extension learning I had.

Created a new node content type for plugin site api, and then the body
will either be MarkdownRemark, or PluginHtml, and its easy to query,
only one will ever be returned.