### PR TITLE
 Autolink headers (html version)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,7 +64,7 @@ module.exports.plugins = [
                 {
                     resolve: '@halkeye/gatsby-rehype-autolink-headers',
                     options: {
-                        elements: ['h1', 'h2', 'h3'],
+                        prependId: 'plugin-content-',
                         isIconAfterHeader: true
                     }
                 },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,6 +49,29 @@ module.exports.plugins = [
             },
         },
     },
+    {
+        resolve: '@halkeye/gatsby-transformer-rehype',
+        options: {
+            filter: node => node.internal.type === 'JenkinsPluginWiki',
+            source: node => node.internal.content,
+            contextFields: [],
+            // EmitParseErrors mode (optional, default: false)
+            emitParseErrors: true,
+            // Verbose mode (optional, default: false)
+            verbose: true,
+            // Plugins configs (optional but most likely you need one)
+            plugins: [
+                {
+                    resolve: '@halkeye/gatsby-rehype-autolink-headers',
+                    options: {
+                        elements: ['h1', 'h2', 'h3'],
+                        isIconAfterHeader: true
+                    }
+                },
+                // 'gatsby-rehype-prismjs',
+            ],
+        }
+    },
     'gatsby-transformer-sharp',
     {
         resolve: 'gatsby-transformer-remark',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,9 +1580,9 @@
       }
     },
     "@halkeye/gatsby-rehype-autolink-headers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-rehype-autolink-headers/-/gatsby-rehype-autolink-headers-1.0.0.tgz",
-      "integrity": "sha512-OyUvEDDoaS2y+LPmPhRtp9Rx74Bn7edYSFY+2uwktdC+aW+WGTHeF6IxgTKCfjNcVzShxpqGavy1FRp63gpR0w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-rehype-autolink-headers/-/gatsby-rehype-autolink-headers-1.0.1.tgz",
+      "integrity": "sha512-zYhmYEjNsC3I5Tr8LYcI7szH1WnJaIlvhXjARwl+BFyXV+Nc0bnP4sxBeGPNamZv7HN9J89dg04RNe3too0nhQ==",
       "requires": {
         "github-slugger": "^1.4.0",
         "hast-util-to-string": "^1.0.4",
@@ -1592,9 +1592,9 @@
       }
     },
     "@halkeye/gatsby-transformer-rehype": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-transformer-rehype/-/gatsby-transformer-rehype-1.0.0.tgz",
-      "integrity": "sha512-ejm6bsSvk2b0BeZuDOsyJbCxfHJnmeRowitcd5qrv+fFomtHqy08vNkYJjmr3Z+kpgbELqz3IYsMNqQXGf0JIg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-transformer-rehype/-/gatsby-transformer-rehype-1.0.1.tgz",
+      "integrity": "sha512-fmZRSX2VwEpsSzR0Yg3ZrvUnYNh5brH34GFw4gaTM2W1wpN6+HfCII/RzFX/RuJds5nbj/mLTqoiZD4SvywBVA==",
       "requires": {
         "@babel/runtime": "7.13.9",
         "hast-util-raw": "^6.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,6 +1579,41 @@
         }
       }
     },
+    "@halkeye/gatsby-rehype-autolink-headers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-rehype-autolink-headers/-/gatsby-rehype-autolink-headers-1.0.0.tgz",
+      "integrity": "sha512-OyUvEDDoaS2y+LPmPhRtp9Rx74Bn7edYSFY+2uwktdC+aW+WGTHeF6IxgTKCfjNcVzShxpqGavy1FRp63gpR0w==",
+      "requires": {
+        "github-slugger": "^1.4.0",
+        "hast-util-to-string": "^1.0.4",
+        "lodash": "^4.17.21",
+        "style-to-object": "^0.3.0",
+        "unist-util-visit": "^2.0.3"
+      }
+    },
+    "@halkeye/gatsby-transformer-rehype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@halkeye/gatsby-transformer-rehype/-/gatsby-transformer-rehype-1.0.0.tgz",
+      "integrity": "sha512-ejm6bsSvk2b0BeZuDOsyJbCxfHJnmeRowitcd5qrv+fFomtHqy08vNkYJjmr3Z+kpgbELqz3IYsMNqQXGf0JIg==",
+      "requires": {
+        "@babel/runtime": "7.13.9",
+        "hast-util-raw": "^6.0.2",
+        "lodash": "^4.17.21",
+        "rehype": "^11.0.0",
+        "unist-util-remove-position": "^3.0.0",
+        "unist-util-visit": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@halkeye/react-paginate": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/@halkeye/react-paginate/-/react-paginate-7.2.3.tgz",
@@ -14781,6 +14816,11 @@
         "zwitch": "^1.0.0"
       }
     },
+    "hast-util-to-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
+      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
+    },
     "hast-util-whitespace": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
@@ -21502,6 +21542,53 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
+      }
+    },
+    "rehype": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/rehype/-/rehype-11.0.0.tgz",
+      "integrity": "sha512-qXqRqiCFJD5CJ61CSJuNImTFrm3zVkOU9XywHDwrUuvWN74MWt72KJ67c5CM5x8g0vGcOkRVCrYj85vqkmHulQ==",
+      "requires": {
+        "rehype-parse": "^7.0.0",
+        "rehype-stringify": "^8.0.0",
+        "unified": "^9.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        },
+        "unified": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+          "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        }
+      }
+    },
+    "rehype-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
+      "integrity": "sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==",
+      "requires": {
+        "hast-util-from-parse5": "^6.0.0",
+        "parse5": "^6.0.0"
+      }
+    },
+    "rehype-stringify": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-8.0.0.tgz",
+      "integrity": "sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==",
+      "requires": {
+        "hast-util-to-html": "^7.1.1"
       }
     },
     "remark": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   "homepage": "https://plugins.jenkins.io/",
   "dependencies": {
     "@babel/core": "^7.15.0",
-    "@halkeye/gatsby-rehype-autolink-headers": "^1.0.0",
-    "@halkeye/gatsby-transformer-rehype": "^1.0.0",
+    "@halkeye/gatsby-rehype-autolink-headers": "^1.0.1",
+    "@halkeye/gatsby-transformer-rehype": "^1.0.1",
     "@halkeye/react-paginate": "^7.2.3",
     "@juggle/resize-observer": "^3.3.1",
     "@sentry/browser": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
   "homepage": "https://plugins.jenkins.io/",
   "dependencies": {
     "@babel/core": "^7.15.0",
+    "@halkeye/gatsby-rehype-autolink-headers": "^1.0.0",
+    "@halkeye/gatsby-transformer-rehype": "^1.0.0",
     "@halkeye/react-paginate": "^7.2.3",
     "@juggle/resize-observer": "^3.3.1",
     "@sentry/browser": "^6.12.0",

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
@@ -38,34 +38,3 @@ exports.createSchemaCustomization = ({actions}) => {
         }
     `);
 };
-
-
-async function onCreateNode({node, actions, loadNodeContent, createNodeId, reporter, createContentDigest}) {
-    if (!['text/pluginhtml'].includes(node.internal.mediaType)) {
-        return;
-    }
-
-    const {createNode, createParentChildLink} = actions; // Load Asciidoc contents
-    const html = await loadNodeContent(node); // Load Asciidoc file for extracting
-
-    try {
-        const htmlNode = {
-            id: createNodeId(`${node.id} >>> PluginHTML`),
-            parent: node.id,
-            internal: {
-                type: 'JenkinsPluginHtml'
-            },
-            children: [],
-            html,
-        };
-
-        htmlNode.internal.contentDigest = createContentDigest(htmlNode);
-        createNode(htmlNode);
-        createParentChildLink({parent: node, child: htmlNode});
-    } catch (err) {
-        reporter.panicOnBuild(`Error processing html ${node.absolutePath ? `file ${node.absolutePath}` : `in node ${node.id}`}:\n ${err.message}`);
-    }
-}
-exports.onCreateNode = onCreateNode;
-
-

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -2,6 +2,7 @@
 const axios = require('axios');
 const path = require('path');
 const crypto = require('crypto');
+const cheerio = require('cheerio');
 const {execSync} = require('child_process');
 const axiosRetry = require('axios-retry');
 const dateFNs = require('date-fns');
@@ -86,6 +87,11 @@ const getPluginContent = async ({wiki, pluginName, reporter, createNode, createC
             }
         }
         const data = await requestGET({reporter, url: `https://plugins.jenkins.io/api/plugin/${pluginName}`});
+
+        const $ = cheerio.load(data.wiki.content);
+        $('a[id^="user-content"][href^="#"]').remove();
+        data.wiki.content = $.html();
+
         return createWikiNode('text/pluginhtml', wiki.url, data.wiki.content);
     } catch (err) {
         reporter.error(`error fetching ${pluginName}`, err);

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -12,7 +12,7 @@ export const PluginFragment = graphql`
         childMarkdownRemark {
             html
         }
-        childJenkinsPluginHtml {
+        childHtmlRehype {
             html
         }
         url

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -331,7 +331,6 @@ transform: scale(-1, 1);
   margin-bottom: .5rem;
 }
 
-.markdown-body .anchor {display:none}
 .content h1 {font-size:2rem; margin:1.5rem 0 1rem;}
 .content h2 {font-size:1.5rem; margin-top:1.5rem;}
 .content h3 {font-size:1.25rem;}

--- a/src/templates/plugin.jsx
+++ b/src/templates/plugin.jsx
@@ -46,8 +46,8 @@ const PluginWikiContent = ({wiki}) => {
     if (wiki?.childMarkdownRemark) {
         return <div className="content" dangerouslySetInnerHTML={{__html: wiki.childMarkdownRemark.html}} />;
     }
-    if (wiki?.childJenkinsPluginHtml) {
-        return <div className="content" dangerouslySetInnerHTML={{__html: wiki.childJenkinsPluginHtml.html}} />;
+    if (wiki?.childHtmlRehype) {
+        return <div className="content" dangerouslySetInnerHTML={{__html: wiki.childHtmlRehype.html}} />;
     }
     return (<div className="content">
         Documentation for this plugin is here:
@@ -61,7 +61,7 @@ PluginWikiContent.propTypes = {
         childMarkdownRemark: PropTypes.shape({
             html: PropTypes.string,
         }),
-        childJenkinsPluginHtml: PropTypes.shape({
+        childHtmlRehype: PropTypes.shape({
             html: PropTypes.string,
         }),
         url: PropTypes.string.isRequired


### PR DESCRIPTION
* forked transformer-rehype which is no longer maintained
* created gatsby-rehype-autolink-headers plugin, based on remark
  (markdown) plugin

Eventually i'd like to move to yarn workspaces and a mono repo so all
the required packages can be in this repo

Demo site:
https://next-cherries.surge.sh/azure-credentials/#using-azure-credentials-in-your-own-jenkins-plugin

Debating if we should prefix the ids at all to prevent collisions with anything build in. Github does user-content-${id} for this reason.