### PR TITLE
Show last build date as relative build time

### DIFF
--- a/plugins/plugin-site/src/components/SiteVersion.jsx
+++ b/plugins/plugin-site/src/components/SiteVersion.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {useStaticQuery, graphql} from 'gatsby';
+import TimeAgo from 'react-timeago';
+import {formatter} from '../commons/helper';
 
 function SiteVersion() {
 
@@ -30,7 +32,10 @@ function SiteVersion() {
             {' / API '}
             <a href={`https://github.com/jenkins-infra/plugin-site-api/commit/${pluginSiteApiVersion}`}>{pluginSiteApiVersion.substr(0, 7)}</a>
             <br />
-            <small>{buildTime}</small>
+            <small>
+                Last Built:
+                {typeof window !== 'undefined' ? <TimeAgo date={new Date(buildTime)} formatter={formatter}/> : buildTime}
+            </small>
         </p>
     );
 }


### PR DESCRIPTION
* When static compiled/without javascript, it'll just show the utc string
* else, show it was "11 minute ago" so no need to figure out UTC

![image](https://user-images.githubusercontent.com/110087/146658337-aa48c114-b8e7-489a-8e4c-ae17c17ce715.png)
