### PR TITLE
Fix #914 by flattening out version and sorting by that

### DIFF
--- a/plugins/gatsby-jenkinsci-fieldextensions/.eslintrc.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/.eslintrc.js
@@ -1,0 +1,109 @@
+module.exports = {
+    'env': {
+        'browser': true,
+        'es6': true,
+        'node': true
+    },
+    'extends': [
+        'eslint:recommended',
+        'plugin:import/recommended',
+        'plugin:react/recommended',
+        'plugin:promise/recommended'
+    ],
+    'overrides': [
+        {
+            'env': {
+                'jest/globals': true
+            },
+            'extends': [
+                'plugin:jest/all'
+            ],
+            'files': [
+                'jest-*.js',
+                '__tests__/**/*.js',
+                '__tests__/**/*.jsx',
+                '__mocks__/**/*.js',
+                '__mocks__/**/*.jsx',
+                '**/*.test.js',
+                '**/*.test.jsx',
+            ],
+            'plugins': [
+                'jest'
+            ],
+            'rules': {
+                'jest/no-hooks': 'off',
+                'jest/prefer-expect-assertions': 'off'
+            }
+        },
+        {
+            'files': [
+                '*config.js',
+            ],
+            'rules': {
+                'sort-keys': 'error'
+            }
+        }
+    ],
+    'parser': '@babel/eslint-parser',
+    'plugins': [
+        'promise',
+        'react',
+        'import'
+    ],
+    'rules': {
+        'comma-spacing': 2,
+        'eol-last': 2,
+        'import/extensions': ['error', 'ignorePackages', {'js': 'never', 'jsx': 'never'}],
+        'import/no-unresolved': [2, {
+            ignore: [
+                '@gatsbyjs/reach-router' // we need to load the one provided by gatsby so they match up and stuff
+            ]
+        }],
+        'indent': ['error', 4],
+        'jsx-quotes': 2,
+        'key-spacing': [2],
+        'max-len': 0,
+        'no-console': 2,
+        'no-extra-semi': 2,
+        'no-multi-spaces': 'error',
+        'no-trailing-spaces': [2, {'skipBlankLines': true}],
+        'no-undef': 2,
+        'no-underscore-dangle': [0],
+        'no-unused-vars': [2],
+        'no-var': 2,
+        'object-curly-spacing': ['error', 'never'],
+        'object-shorthand': [0, 'always'],
+        'prefer-arrow-callback': 2,
+        'prefer-const': 2,
+        'prefer-template': 2,
+        'quote-props': [0, 'as-needed'],
+        'quotes': [2, 'single'],
+        'react/display-name': 0,
+        'react/jsx-boolean-value': 2,
+        'react/jsx-curly-spacing': [2, {'allowMultiline': true, 'when': 'never'}],
+        'react/jsx-equals-spacing': [2, 'never'],
+        'react/jsx-filename-extension': [1, {'extensions': ['.js', '.jsx']}],
+        'react/jsx-indent': ['error', 4, {'checkAttributes': true, 'indentLogicalExpressions': true}],
+        'react/jsx-no-undef': 2,
+        'react/jsx-one-expression-per-line': ['error', {'allow': 'single-child'}],
+        'react/jsx-sort-props': 0,
+        'react/jsx-uses-react': 2,
+        'react/jsx-uses-vars': 2,
+        'react/jsx-wrap-multilines': 2,
+        'react/no-did-mount-set-state': 2,
+        'react/no-did-update-set-state': 2,
+        'react/no-multi-comp': 0,
+        'react/no-unknown-property': 2,
+        'react/prop-types': 2,
+        'react/react-in-jsx-scope': 2,
+        'react/self-closing-comp': 2,
+        'semi': [2],
+        'space-before-function-paren': [2, {'anonymous': 'always', 'named': 'never'}],
+        'strict': [2, 'global'],
+    },
+    'settings': {
+        'import/extensions': ['.js', '.jsx'],
+        'import/resolver': {'node': {'extensions': ['.js', '.jsx']}},
+        'react': {'version': 'detect'},
+    },
+};

--- a/plugins/gatsby-jenkinsci-fieldextensions/babel.config.json
+++ b/plugins/gatsby-jenkinsci-fieldextensions/babel.config.json
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ]
+}

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
@@ -1,0 +1,42 @@
+const cheerio = require('cheerio');
+
+exports.createSchemaCustomization = ({actions}) => {
+    const {createFieldExtension} = actions;
+
+    createFieldExtension({
+        name: 'strippedHtml',
+        args: {
+            field: 'String',
+        },
+        extend(options = {}) {
+            return {
+                resolve(source) {
+                    const field = options.field || 'html';
+                    return cheerio.load(source[field]).text();
+                },
+            };
+        },
+    });
+    createFieldExtension({
+        name: 'machineVersion',
+        description: 'returns machine sortable version',
+        args: {
+            field: 'String',
+        },
+        extend(options = {}) {
+            const padArrayEnd = (arr, len, padding) => {
+                return arr.concat(Array(Math.max(len - arr.length, 0)).fill(padding));
+            };
+            return {
+                resolve(source) {
+                    const value = source[options.field || 'version'].toString() || '';
+                    // make sure the version has 3 parts and 5 length (just in case)
+                    // so 1.2.3 and 1.2 sort right
+                    // 2.29 => 00002_00029_00000
+                    // 2.290 => 00002_00290_00000
+                    return padArrayEnd(value.split('.'), 4, 0).map(val => val.toString().padStart(5, '0')).join('_');
+                },
+            };
+        },
+    });
+};

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+const {createSchemaCustomization} = require('./gatsby-node');
+
+describe('gatsby-node', () => {
+    describe('createSchemaCustomization', () => {
+        const fieldExtensions = {};
+        beforeAll(() => {
+            createSchemaCustomization({
+                actions: {
+                    createTypes: jest.fn(),
+                    createFieldExtension: ({name, extend}) => {
+                        fieldExtensions[name] = extend;
+                    }
+                }
+            });
+        });
+        describe('machineVersion', () => {
+            it('0.0.0', () => {
+                const value = fieldExtensions.machineVersion({field: 'version'}).resolve({version: '0.0.0'});
+                expect(value).toBe('00000_00000_00000_00000');
+            });
+            it('4.7.1.1', () => {
+                const value = fieldExtensions.machineVersion({field: 'version'}).resolve({version: '4.7.1.1'});
+                expect(value).toBe('00004_00007_00001_00001');
+            });
+        });
+        describe('strippedHtml', () => {
+            it('basic', () => {
+                const value = fieldExtensions.strippedHtml().resolve({html: '<div><h1>Header</h1>body</div>'});
+                expect(value).toBe('Headerbody');
+            });
+        });
+    });
+});
+

--- a/plugins/gatsby-jenkinsci-fieldextensions/package.json
+++ b/plugins/gatsby-jenkinsci-fieldextensions/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@jenkins-cd/gatsby-jenkinsci-fieldextensions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint --ext .js,.jsx .",
+    "build": "exit 0",
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "Gavin Mogan <npm@gavinmogan.com> (https://www.gavinmogan.com/)",
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "27.4.5"
+  },
+  "dependencies": {
+    "cheerio": "1.0.0-rc.10"
+  }
+}

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.js
@@ -35,13 +35,16 @@ exports.createSchemaCustomization = ({actions}) => {
     createTypes(`
         type JenkinsPlugin implements Node {
             wiki: JenkinsPluginWiki @link(from: "name", by: "name")
-            buildDate: Date
-            previousTimestamp: Date
-            releaseTimestamp: Date
+            releases: [JenkinsPluginVersion] @link(from: "name", by: "name")
+            buildDate: Date @dateformat
+            previousTimestamp: Date @dateformat
+            releaseTimestamp: Date @dateformat
         }
 
         type JenkinsPluginVersion implements Node {
-            buildDate: Date
+            buildDate: Date @dateformat
+            plugin: JenkinsPlugin @link(from: "name", by: "name")
+            machineVersion: String @machineVersion(field: "version")
         }
     `);
 };

--- a/plugins/plugin-site/gatsby-config.js
+++ b/plugins/plugin-site/gatsby-config.js
@@ -43,6 +43,9 @@ module.exports = {
 
 module.exports.plugins = [
     {
+        resolve: '@jenkins-cd/gatsby-jenkinsci-fieldextensions'
+    },
+    {
         resolve: 'gatsby-transformer-asciidoc',
         options: {
             attributes: {

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -293,7 +293,7 @@ export const pageQuery = graphql`
       ...JenkinsPluginFragment
     }
 
-    versions: allJenkinsPluginVersion(filter: {name: {eq: $name}}, sort: {fields: buildDate, order: DESC}) {
+    versions: allJenkinsPluginVersion(filter: {name: {eq: $name}}, sort: {fields: machineVersion, order: DESC}) {
       edges {
         node {
           buildDate

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,6 +3023,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jenkins-cd/gatsby-jenkinsci-fieldextensions@workspace:plugins/gatsby-jenkinsci-fieldextensions":
+  version: 0.0.0-use.local
+  resolution: "@jenkins-cd/gatsby-jenkinsci-fieldextensions@workspace:plugins/gatsby-jenkinsci-fieldextensions"
+  dependencies:
+    cheerio: 1.0.0-rc.10
+    jest: 27.4.5
+  languageName: unknown
+  linkType: soft
+
 "@jenkins-cd/gatsby-rehype-rewrite-img-src@*, @jenkins-cd/gatsby-rehype-rewrite-img-src@workspace:plugins/gatsby-rehype-rewrite-img-src":
   version: 0.0.0-use.local
   resolution: "@jenkins-cd/gatsby-rehype-rewrite-img-src@workspace:plugins/gatsby-rehype-rewrite-img-src"


### PR DESCRIPTION
Originally it was sorting by buildDate, but that only returns the date, not time
Switch over to using `@machineVersion` gatsby field extension, which
turns 1.2.3 to 00001_00002_00003 which makes it way easier to sort.

Create a new module so it can be tested and eventually added to
gatsby-jenkins.io