### PR TITLE
Delete .kodiak.toml

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,7 +1,0 @@
-# .kodiak.toml
-# Minimal config. version is the only required field.
-version = 1
-[merge.automerge_dependencies]
-versions = ["minor", "patch"]
-# only automerge by upgrade version for pull requests authored by dependabot.
-usernames = ["dependabot"]


### PR DESCRIPTION
no longer using it as renovate supports automerge