### PR TITLE
Use more resources - these builds are too slow

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -55,6 +55,11 @@ spec:
     - name: "jnlp"
       image: "jenkinsciinfra/builder"
       imagePullPolicy: Always
+      resources:
+        limits: {}
+        requests:
+          memory: "2Gi"
+          cpu: "1"
       '''
     }
   }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -58,8 +58,8 @@ spec:
       resources:
         limits: {}
         requests:
-          memory: "2Gi"
-          cpu: "1"
+          memory: "4Gi"
+          cpu: "2"
       '''
     }
   }


### PR DESCRIPTION
13 minutes to install dependencies - [infra.ci.jenkins.io](https://infra.ci.jenkins.io/job/plugin-site/job/PR-958/11/console)  (200m cpu, 256mb memory)
2m30 - [ci.jenkins.io on VM](https://ci.jenkins.io/blue/organizations/jenkins/Infra%2Fplugin-site/detail/PR-958/14/pipeline/19)

11m 34s with 1 cpu 2gb memory
2m 9s with 2 cpu 4gb memory