### PR TITLE
Abort previous builds on CI

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -74,7 +74,7 @@ spec:
   options {
     timeout(time: 60, unit: 'MINUTES')
     ansiColor('xterm')
-    disableConcurrentBuilds()
+    disableConcurrentBuilds(abortPrevious: true)
     buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '5', numToKeepStr: '5')
   }
 


### PR DESCRIPTION
No point waiting for the previous result just start the new build, i.e after rebase / whatever

wasting lots of CI time with this setting