### PR TITLE
Use full sha in the Jenkinsfile so renovate regex matches it

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -53,7 +53,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: "jnlp"
-      image: "jenkinsciinfra/builder:2.0.3"
+      image: "jenkinsciinfra/builder:2.0.3@sha256:562ca29a65a85738b96ff49416e99e338b65a5c47161acc9acbe23c5f870fa6e"
       resources:
         limits: {}
         requests:


### PR DESCRIPTION
tested via https://regex101.com/

I'll do another PR later for the nodejs versions in Jenkinsfile, since #961 updates node anyways