### PR TITLE
Have one github preview environment per PR

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -7,7 +7,7 @@ def recordDeployment(owner, repo, ref, status, environmentURL, environment = "pr
         "required_contexts": [],
         "auto_merge": false,
         "auto_inactive": false,
-        "transient_environment": false,
+        "transient_environment": environment != "production",
     ])
     def id = readJSON(text: sh(script: "gh api repos/${owner}/${repo}/deployments  -X POST --input - << EOF\n${json}\nEOF", returnStdout: true).trim()).id
     if (id == ''){
@@ -171,10 +171,10 @@ spec:
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app", "preview-${CHANGE_ID}")
+          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app")
         }
         failure {
-          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app", "preview-${CHANGE_ID}")
+          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app")
         }
       }
       steps {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -171,10 +171,10 @@ spec:
       }
       post {
         success {
-          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app")
+          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'success', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app", "preview-${CHANGE_ID}")
         }
         failure {
-          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app")
+          recordDeployment('jenkins-infra', 'plugin-site', pullRequest.head, 'failure', "https://deploy-preview-${CHANGE_ID}--jenkins-plugin-site-pr.netlify.app", "preview-${CHANGE_ID}")
         }
       }
       steps {


### PR DESCRIPTION
Right now when one PR deploys, the previous deploy gets marked as inactive since they are the same env. So make env separate for each PR.