### PR TITLE
Convert more svg elements into camelcase for react

### DIFF
--- a/plugins/plugin-site/makeLayout.js
+++ b/plugins/plugin-site/makeLayout.js
@@ -97,11 +97,26 @@ async function makeReactLayout() {
         'charSet': 'charset',
         'http-equiv': 'httpEquiv',
         'stop-color': 'stopColor',
-        'crossorigin': 'crossOrigin'
+        'crossorigin': 'crossOrigin',
+        'lineargradient': 'linearGradient',
+        'gradienttransform': 'gradientTransform',
+        'gradientunits': 'gradientUnits',
+        'viewbox': 'viewBox',
+        'xlink:href': 'xlinkHref',
+        'xmlns:xlink': 'xmlnsXlink',
+    };
+
+    const nodeConversions = {
+        'lineargradient': 'linearGradient',
+        'gradienttransform': 'gradientTransform',
     };
 
     const handleNode = (node, indent = 0) => {
         const prefix = ''.padStart(6+indent);
+
+        if (node.name) {
+            node.name = nodeConversions[node.name] || node.name;
+        }
 
         if (node.name === 'link' && node.attribs && node.attribs.rel === 'stylesheet') {
             delete node.attribs.crossorigin;


### PR DESCRIPTION
From my work on stories.jenkins.io i found that that the cdf logo
wouldn't render properly. I'm guessing its due to newer gatsby/react, so
to get ahead of us eventually upgrading, i'm backporting these fixes