### PR TITLE
PropTypes.bool not PropTypes.boolean (which doesnt exist)

### DIFF
--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -245,7 +245,7 @@ PluginPage.propTypes = {
                 viewUrl: PropTypes.string,
                 reportUrl: PropTypes.string,
             })),
-            hasPipelineSteps: PropTypes.boolean,
+            hasPipelineSteps: PropTypes.bool,
             excerpt: PropTypes.string,
             gav: PropTypes.string.isRequired,
             hasBomEntry: PropTypes.bool,


### PR DESCRIPTION
Tests were spitting out warnings, but warnings dont break the build, so
was easily missed