### PR TITLE
At some point when we moved all wiki docs to export, the banner for migration broke

### DIFF
--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -28,7 +28,7 @@ function shouldShowWikiUrl({url}) {
 }
 
 function shouldShowGitHubUrl({url}) {
-    return url?.startsWith('https://github.com/') && !shouldShowGitHubUrl(url);
+    return url?.startsWith('https://github.com/') && !shouldShowWikiUrl({url});
 }
 
 const PluginWikiContent = ({wiki}) => {

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -21,11 +21,14 @@ import PluginReleases from '../components/PluginReleases';
 import PluginIssueTrackers from '../components/PluginIssueTrackers';
 
 function shouldShowWikiUrl({url}) {
-    return url?.startsWith('https://wiki.jenkins-ci.org/') || url?.startsWith('https://wiki.jenkins.io/') || url?.includes('github.com/jenkins-infra/plugins-wiki-docs');
+    return url?.startsWith('https://wiki.jenkins-ci.org/') ||
+        url?.startsWith('https://wiki.jenkins.io/') ||
+        url?.includes('github.com/jenkins-infra/plugins-wiki-docs') ||
+        url?.includes('raw.githubusercontent.com/jenkins-infra/plugins-wiki-doc');
 }
 
 function shouldShowGitHubUrl({url}) {
-    return url && url.startsWith('https://github.com/');
+    return url?.startsWith('https://github.com/') && !shouldShowGitHubUrl(url);
 }
 
 const PluginWikiContent = ({wiki}) => {


### PR DESCRIPTION
as noted on https://github.com/jenkins-infra/plugins-wiki-docs/pull/5#issuecomment-1070647496