### PR TITLE
Remove some columns from issues tab

### DIFF
--- a/plugins/plugin-site/src/components/PluginIssues.jsx
+++ b/plugins/plugin-site/src/components/PluginIssues.jsx
@@ -1,6 +1,8 @@
 import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import axios from 'axios';
+import TimeAgo from 'react-timeago';
+import {formatter} from '../commons/helper';
 
 function PluginIssues({pluginId}) {
     const [isLoading, setIsLoading] = useState(false);
@@ -34,11 +36,6 @@ function PluginIssues({pluginId}) {
                         <tr>
                             <th scope="col">Key</th>
                             <th scope="col">Summary</th>
-                            <th scope="col">Assignee</th>
-                            <th scope="col">Reporter</th>
-                            <th scope="col">Priority</th>
-                            <th scope="col">Status</th>
-                            <th scope="col">Resolution</th>
                             <th scope="col">Created</th>
                             <th scope="col">Updated</th>
                         </tr>
@@ -49,13 +46,8 @@ function PluginIssues({pluginId}) {
                                 <tr key={issue.key}>
                                     <th scope="row"><a href={issue.url}>{issue.key}</a></th>
                                     <td>{issue.summary}</td>
-                                    <td>{issue.assignee}</td>
-                                    <td>{issue.reporter}</td>
-                                    <td>{issue.priority}</td>
-                                    <td>{issue.status}</td>
-                                    <td>{issue.resolution}</td>
-                                    <td>{issue.created}</td>
-                                    <td>{issue.updated}</td>
+                                    <td><TimeAgo date={new Date(issue.created)} formatter={formatter}/></td>
+                                    <td><TimeAgo date={new Date(issue.updated)} formatter={formatter}/></td>
                                 </tr>
                             );
                         })}

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -134,7 +134,11 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                             }
 
                             if (selectedTab.id === 'issues') {
-                                return <PluginIssues pluginId={plugin.name} />;
+                                if (plugin?.issueTrackers?.length) {
+                                    return <PluginIssues pluginId={plugin.name} />;
+                                } else {
+                                    return <div className="alert alert-warning mt-3">This plugin does not specify any issue tracker.</div>;
+                                }
                             }
                             if (selectedTab.id === 'dependencies') {
                                 return (


### PR DESCRIPTION
* Some columns are redundant since we only show open issues (resolution, status), some are only relevant for developers of given plugin (assignee, reporter, priority).
* Date columns (created/updated) should be formatted: changed to the "time ago" format here
* If no trackers are available, show a warning instead of trying and failing to fetch the issues