### PR TITLE
Add extensions link in plugin page

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -130,11 +130,11 @@ Array [
     "firstRelease": "1970-01-01T00:00:00.000Z",
     "gav": "org.jenkins-ci.plugins:ios-device-connector:1.2",
     "hasBomEntry": false,
+    "hasExtensions": false,
     "hasPipelineSteps": false,
-    "hasExtensions":false,
     "id": "ios-device-connector <<< JenkinsPlugin",
     "internal": Object {
-      "contentDigest": "f5534973aae4f62f5c453dca7f0f45e3",
+      "contentDigest": "1da1c7c8d56f5351f4d3c618759f7689",
       "type": "JenkinsPlugin",
     },
     "issueTrackers": Array [

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.js.snap
@@ -131,6 +131,7 @@ Array [
     "gav": "org.jenkins-ci.plugins:ios-device-connector:1.2",
     "hasBomEntry": false,
     "hasPipelineSteps": false,
+    "hasExtensions":false,
     "id": "ios-device-connector <<< JenkinsPlugin",
     "internal": Object {
       "contentDigest": "f5534973aae4f62f5c453dca7f0f45e3",

--- a/plugins/gatsby-source-jenkinsplugins/utils.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.js
@@ -117,7 +117,7 @@ const getPluginContent = async ({wiki, pluginName, reporter, createNode, createC
     }
 };
 
-const processPlugin = ({createNode, names, stats, updateData, detachedPlugins, canonicalLabels, documentation, bomDependencies, pipelinePluginIds, firstReleases, createContentDigest, createNodeId, createNodeField, createRemoteFileNode, reporter, plugin}) => {
+const processPlugin = ({createNode, names, stats, updateData, detachedPlugins, canonicalLabels, documentation, bomDependencies, pipelinePluginIds, pluginExtensionList, firstReleases, createContentDigest, createNodeId, createNodeField, createRemoteFileNode, reporter, plugin}) => {
     return async function () {
         const pluginName = plugin.name.trim();
         names.push(pluginName);
@@ -140,6 +140,7 @@ const processPlugin = ({createNode, names, stats, updateData, detachedPlugins, c
             dependencies: allDependencies,
             firstRelease: firstReleases[pluginName] && firstReleases[pluginName].toISOString(),
             hasPipelineSteps: pipelinePluginIds.includes(pluginName),
+            hasExtensions: pluginExtensionList.includes(pluginName),
             hasBomEntry: !!bomDependencies.find(artifactId => plugin.gav.includes(`:${artifactId}:`)),
             parent: null,
             children: [],
@@ -199,6 +200,9 @@ const fetchPluginData = async ({createNode, createContentDigest, createNodeId, c
     const documentationListUrl = 'https://updates.jenkins.io/current/plugin-documentation-urls.json';
     const documentation = await requestGET({url: documentationListUrl, reporter});
 
+    const pluginExtensionsUrl = 'https://www.jenkins.io/doc/developer/extensions/contents.json';
+    const pluginExtensionList = await requestGET({url: pluginExtensionsUrl, reporter});
+
     const canonicalLabelPairs = await getCoreResourceAsTuples('jenkins/canonical-labels.txt', ' ', reporter);
     const canonicalLabels = {};
     for (const [key, value] of canonicalLabelPairs) {
@@ -216,6 +220,7 @@ const fetchPluginData = async ({createNode, createContentDigest, createNodeId, c
         documentation,
         bomDependencies,
         pipelinePluginIds,
+        pluginExtensionList,
         firstReleases,
         createNode,
         createContentDigest,

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.js
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.js
@@ -51,6 +51,9 @@ describe('utils', () => {
         nock('https://www.jenkins.io')
             .get('/doc/pipeline/steps/contents.json')
             .reply(200, []);
+        nock('https://www.jenkins.io')
+            .get('/doc/developer/extensions/contents.json')
+            .reply(200, []);
         nock('https://raw.githubusercontent.com:443')
             .get('/jenkinsci/bom/master/bom-weekly/pom.xml')
             .reply(200, '');

--- a/plugins/plugin-site/src/fragments.js
+++ b/plugins/plugin-site/src/fragments.js
@@ -42,6 +42,7 @@ export const PluginFragment = graphql`
     }
     scm
     hasPipelineSteps
+    hasExtensions
     requiredCore
     releaseTimestamp
     previousVersion

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -176,7 +176,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                         {plugin.scm && <div className="label-link"><a href={plugin.scm}>GitHub</a></div>}
                         <PluginIssueTrackers issueTrackers={plugin.issueTrackers} />
                         {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline Step Reference</a></div>}
-                        {plugin.hasExtensions && <div className="label-link"><a href={`https://www.jenkins.io/doc/developer/extensions/${plugin.name}`}>Extensions</a></div>}
+                        {plugin.hasExtensions && <div className="label-link"><a href={`https://www.jenkins.io/doc/developer/extensions/${plugin.name}`}>Extension Points</a></div>}
                         <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
                     </div>
                     <div className="sidebarSection">

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -178,7 +178,7 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                         {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline Step Reference</a></div>}
                         {plugin.hasExtensions && <div className="label-link"><a href={`https://www.jenkins.io/doc/developer/extensions/${plugin.name}`}>Extensions</a></div>}
                         <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
-                    </div>                   
+                    </div>
                     <div className="sidebarSection">
                         <h5>Labels</h5>
                         <PluginLabels labels={plugin.labels} />

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -176,8 +176,9 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
                         {plugin.scm && <div className="label-link"><a href={plugin.scm}>GitHub</a></div>}
                         <PluginIssueTrackers issueTrackers={plugin.issueTrackers} />
                         {plugin.hasPipelineSteps && <div className="label-link"><a href={`https://www.jenkins.io/doc/pipeline/steps/${plugin.name}`}>Pipeline Step Reference</a></div>}
+                        {plugin.hasExtensions && <div className="label-link"><a href={`https://www.jenkins.io/doc/developer/extensions/${plugin.name}`}>Extensions</a></div>}
                         <div className="label-link"><a href={`https://javadoc.jenkins.io/plugin/${plugin.name}`}>Javadoc</a></div>
-                    </div>
+                    </div>                   
                     <div className="sidebarSection">
                         <h5>Labels</h5>
                         <PluginLabels labels={plugin.labels} />
@@ -253,6 +254,7 @@ PluginPage.propTypes = {
                 reportUrl: PropTypes.string,
             })),
             hasPipelineSteps: PropTypes.bool,
+            hasExtensions: PropTypes.bool,
             excerpt: PropTypes.string,
             gav: PropTypes.string.isRequired,
             hasBomEntry: PropTypes.bool,


### PR DESCRIPTION
Fetch available plugin extensions from https://www.jenkins.io/doc/developer/extensions/contents.json
And use this list to check plugin has extensions in Plugin Page. If it has show link to plugin's extensions page.

issue link: https://github.com/jenkins-infra/plugin-site/issues/1131