### PR TITLE
Remove report problem button from footer for plugins

### DIFF
--- a/plugins/plugin-site/src/components/ReportAProblem.jsx
+++ b/plugins/plugin-site/src/components/ReportAProblem.jsx
@@ -27,9 +27,9 @@ function ReportAProblem({reportProblemTitle, reportProblemUrl, reportProblemRela
 }
 
 ReportAProblem.propTypes = {
-    reportProblemTitle: PropTypes.string.isRequired,
-    reportProblemUrl: PropTypes.string.isRequired,
-    reportProblemRelativeSourcePath: PropTypes.string.isRequired
+    reportProblemTitle: PropTypes.string,
+    reportProblemUrl: PropTypes.string,
+    reportProblemRelativeSourcePath: PropTypes.string
 };
 
 export default ReportAProblem;

--- a/plugins/plugin-site/src/components/ReportAProblem.jsx
+++ b/plugins/plugin-site/src/components/ReportAProblem.jsx
@@ -3,10 +3,22 @@ import PropTypes from 'prop-types';
 
 function ReportAProblem({reportProblemTitle, reportProblemUrl, reportProblemRelativeSourcePath}) {
     const title = `Report a problem with ${reportProblemRelativeSourcePath}`;
-    const pluginSiteReportUrl = `https://github.com/jenkins-infra/plugin-site/issues/new?labels=bug&template=4-bug.md&title=${reportProblemTitle} page - TODO: Put a summary here&body=Problem with the [${reportProblemTitle}](https://plugins.jenkins.io${reportProblemUrl}) page, [source file](https://github.com/jenkins-infra/plugin-site/tree/master/src/${reportProblemRelativeSourcePath})%0A%0ATODO: Describe the expected and actual behavior here %0A%0A%23%23 Screenshots %0A%0A TODO: Add screenshots if possible %0A%0A%23%23 Possible Solution %0A%0A%3C!-- If you have suggestions on a fix for the bug, please describe it here. --%3E %0A%0AN/A`;
-    return (
+    const body = `Problem with the [${reportProblemTitle}](https://plugins.jenkins.io${reportProblemUrl}) page, [source file](https://github.com/jenkins-infra/plugin-site/tree/master/src/${reportProblemRelativeSourcePath})
+
+    TODO: Describe the expected and actual behavior here
+
+    %23%23 Screenshots
+    TODO: Add screenshots if possible
+
+    %23%23 Possible Solution
+
+    %3C!-- If you have suggestions on a fix for the bug, please describe it here. --%3E
+
+    N/A`.replace(/\n */g, '%0A');
+    const pluginSiteReportUrl = `https://github.com/jenkins-infra/plugin-site/issues/new?labels=bug&template=4-bug.md&title=${reportProblemTitle} page - TODO: Put a summary here&body=${body}`;
+    return !reportProblemTitle ? '' : (
         <p className="box">
-            <a href={reportProblemUrl.includes('://') ? reportProblemUrl : pluginSiteReportUrl} title={title}>
+            <a href={pluginSiteReportUrl} title={title}>
                 <ion-icon class="report" name="warning" />
                 Report a problem
             </a>

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -99,16 +99,13 @@ function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseD
 
     const selectedTab = useSelectedPluginTab(tabs);
 
-    const pluginPage = 'templates/plugin.jsx';
-
     const [isShowInstructions, setShowInstructions] = React.useState(false);
     const toggleShowInstructions = (e) => {
         e && e.preventDefault();
         setShowInstructions(!isShowInstructions);
     };
     return (
-        <Layout id="pluginPage" reportProblemRelativeSourcePath={pluginPage} reportProblemTitle={plugin.title}
-            reportProblemUrl={plugin?.issueTrackers?.find(tracker => tracker.reportUrl)?.reportUrl || `/${plugin.name}`}>
+        <Layout id="pluginPage">
             <SEO title={cleanTitle(plugin.title)} description={plugin.excerpt} pathname={`/${plugin.name}`}/>
             <div className="title-wrapper">
                 <h1 className="title">


### PR DESCRIPTION
Report problem should be available only nce per page: right column for plugins (report functionality or documentation problem to maintainers), footer on search page and homepage (report problem with plugin site)

Fixes #1199