### PR TITLE
Avoid Gatsby warning in development mode

### DIFF
--- a/plugins/plugin-site/src/hooks/useSelectedTab.js
+++ b/plugins/plugin-site/src/hooks/useSelectedTab.js
@@ -1,0 +1,4 @@
+export function useSelectedPluginTab(tabs) {
+    const tabName = global?.window?.location?.hash?.replace('#', '') || tabs[0].id;
+    return tabs.find(tab => tab.id === tabName) || tabs[0];
+}

--- a/plugins/plugin-site/src/templates/plugin.jsx
+++ b/plugins/plugin-site/src/templates/plugin.jsx
@@ -20,6 +20,8 @@ import PluginIssues from '../components/PluginIssues';
 import PluginReleases from '../components/PluginReleases';
 import PluginIssueTrackers from '../components/PluginIssueTrackers';
 
+import {useSelectedPluginTab} from '../hooks/useSelectedTab';
+
 function shouldShowWikiUrl({url}) {
     return url?.startsWith('https://wiki.jenkins-ci.org/') ||
         url?.startsWith('https://wiki.jenkins.io/') ||
@@ -83,11 +85,6 @@ Tabs.propTypes = {
     })),
     selectedTab: PropTypes.string.isRequired
 };
-
-export function useSelectedPluginTab(tabs) {
-    const tabName = global?.window?.location?.hash?.replace('#', '') || tabs[0].id;
-    return tabs.find(tab => tab.id === tabName) || tabs[0];
-}
 
 function PluginPage({data: {jenkinsPlugin: plugin, reverseDependencies: reverseDependencies, versions}}) {
     const tabs = [

--- a/plugins/plugin-site/src/templates/plugin.test.jsx
+++ b/plugins/plugin-site/src/templates/plugin.test.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 
 import {render} from '@testing-library/react';
 
-import PluginPage, {useSelectedPluginTab} from './plugin';
+import {useSelectedPluginTab} from '../hooks/useSelectedTab';
+
+import PluginPage from './plugin';
 
 describe('component - PluginPage', () => {
     it('renders', async () => {


### PR DESCRIPTION
`yarn dev` complains that `plugin.jsx` should only export the template and query, this moves a helper function to a separate file to make the warning disappear.