### PR TITLE
More robust plugin version comparison

### DIFF
--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
@@ -27,14 +27,18 @@ exports.createSchemaCustomization = ({actions}) => {
             const padArrayEnd = (arr, len, padding) => {
                 return arr.concat(Array(Math.max(len - arr.length, 0)).fill(padding));
             };
+            // qualifiers alphabetically sorted: a(lpha) < b(eta) < r(c) < s(table)
+            const getQualifier = val => val.toString().match(/^(rc|a\d|b\d)/) ? val.charAt(0) : 's';
             return {
                 resolve(source) {
                     const value = source[options.field || 'version'].toString() || '';
                     // make sure the version has 3 parts and 5 length (just in case)
                     // so 1.2.3 and 1.2 sort right
-                    // 2.29 => 00002_00029_00000
-                    // 2.290 => 00002_00290_00000
-                    return padArrayEnd(value.split('.'), 4, 0).map(val => val.toString().padStart(5, '0')).join('_');
+                    // 2.29 => s00002_s00029_s00000
+                    // 2.290 => s00002_s00290_s00000
+                    // 2.290-rc4 => s00002_s00290_r00004
+                    return padArrayEnd(value.split(/[.-]/), 4, 0).map(val => getQualifier(val)
+                                + val.toString().replace(/^rc/, '').replace(/^[ab](\d)/, '$1').padStart(5, '0')).join('_');
                 },
             };
         },

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
@@ -18,15 +18,18 @@ describe('gatsby-node', () => {
             });
         });
         describe('machineVersion', () => {
-            it('0.0.0', () => {
-                const value = fieldExtensions.machineVersion({field: 'version'}).resolve({version: '0.0.0'});
-                expect(value).toBe('00000_00000_00000_00000');
-            });
-            it('4.7.1.1', () => {
-                const value = fieldExtensions.machineVersion({field: 'version'}).resolve({version: '4.7.1.1'});
-                expect(value).toBe('00004_00007_00001_00001');
-            });
+            const versions = ['0.1', '1.0-b9', '1.0-b10', '1.0-rc2', '1.0', '1.0.9', '1.0.10',
+                '1.0.10-2', '1.1', '2.0', '4.7.1.1'];
+            for (let idx = 1; idx < versions.length; idx++) {
+                it (`sorted ${versions[idx - 1]} ${versions[idx]}`, () => {
+                    const oldVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx - 1]});
+                    const newVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx]});
+                    // localeCompare instead of < to keep ESLint happy
+                    expect(oldVal.localeCompare(newVal)).toBe(-1);
+                });
+            }
         });
+
         describe('strippedHtml', () => {
             it('basic', () => {
                 const value = fieldExtensions.strippedHtml().resolve({html: '<div><h1>Header</h1>body</div>'});

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
@@ -21,7 +21,7 @@ describe('gatsby-node', () => {
             const versions = ['0.1', '1.0-b9', '1.0-b10', '1.0-rc2', '1.0', '1.0.9', '1.0.10',
                 '1.0.10-2', '1.1', '2.0', '4.7.1.1'];
             for (let idx = 1; idx < versions.length; idx++) {
-                it (`sorted ${versions[idx - 1]} ${versions[idx]}`, () => {
+                it (`Version ${versions[idx - 1]} should be less than ${versions[idx]}`, () => {
                     const oldVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx - 1]});
                     const newVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx]});
                     // localeCompare instead of < to keep ESLint happy


### PR DESCRIPTION
Improve comparing of Jenkins plugin versions to cover `1.2-3` and `1.2.rc3`

Fixes #1193 