### PR TITLE
Move suspended plugins banner to the top of the page

### DIFF
--- a/plugins/plugin-site/src/components/SuspendedPlugins.jsx
+++ b/plugins/plugin-site/src/components/SuspendedPlugins.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Link} from 'gatsby';
 
 function SuspendedPlugins({pluginIds}) {
-    return (!!pluginIds.length && <div className="alert alert-info">
+    return (!!pluginIds.length && <div className="alert alert-warning">
         <>One or more suspended plugins match your query: </>
         <>
             {pluginIds.map((name, index) => {

--- a/plugins/plugin-site/src/templates/search.jsx
+++ b/plugins/plugin-site/src/templates/search.jsx
@@ -173,6 +173,7 @@ function SearchPage({location}) {
                             />
                         </div>
                     </div>
+                    <SuspendedPlugins pluginIds={suspendedPlugins.filter(e => query && query.length >2 && e.includes(query))}/>
                     <div className="view">
                         <div className="col-md-12">
                             <SearchResults
@@ -182,7 +183,6 @@ function SearchPage({location}) {
                                 setPage={setPage}
                                 results={results}
                             />
-                            <SuspendedPlugins pluginIds={suspendedPlugins.filter(e => query && query.length >2 && e.includes(query))}/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Moves the suspended plugin banner to the top of the page and uses the banner design used on the plugin's page, rather than the common blue.