### PR TITLE
Shift quality gate for typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,13 @@
+[files]
+extend-exclude = [
+    "*.map",
+    "*.min.css",
+    "*.min.js",
+    "*.js",
+    "*.css",
+    "*.svg",
+    "plugins/gatsby-source-jenkinsplugins/categories.json"
+]
+
+[default]
+check-filename = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ pipeline {
     stage('Check for typos') {
       steps {
         sh '''
-          curl -qsL https://github.com/crate-ci/typos/releases/download/v1.5.0/typos-v1.5.0-x86_64-unknown-linux-musl.tar.gz | tar xvzf - ./typos
+          curl -qsL https://github.com/crate-ci/typos/releases/download/v1.13.19/typos-v1.13.19-x86_64-unknown-linux-musl.tar.gz | tar xvzf - ./typos
           curl -qsL https://github.com/halkeye/typos-json-to-checkstyle/releases/download/v0.1.1/typos-checkstyle-v0.1.1-x86_64 > typos-checkstyle && chmod 0755 typos-checkstyle
           ./typos --format json | ./typos-checkstyle - > checkstyle.xml || true
         '''
-        recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')])
+        recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')], qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]])
       }
     }
 


### PR DESCRIPTION
Similar to jenkins.io, we shouldn't return a stable build indicator if typos are present.