### PR TITLE
Fix: Search By Algolia Alignment

### DIFF
--- a/plugins/plugin-site/src/templates/search.jsx
+++ b/plugins/plugin-site/src/templates/search.jsx
@@ -157,7 +157,7 @@ function SearchPage({location}) {
                         </div>
                     </div>
                     <div className="row">
-                        <div className="col-md-12 text-center">
+                        <div className="col-md-9 text-center">
                             <SearchByAlgolia />
                         </div>
                     </div>


### PR DESCRIPTION
- Bug: 'Search By Algolia' hyperlink not centered below the search bar. 
- Fix: Centered the hyperlink perfectly below the search bar by editing class. 
- Verified the fix in different screen sizes.

Before
![image](https://user-images.githubusercontent.com/62999423/216121497-2fe0af36-f810-4b3f-b3ae-7a48a8743d62.png)

After Fix
![image](https://user-images.githubusercontent.com/62999423/216121530-c125a4f5-8652-44ef-84f1-683623d1d3f0.png)
