### PR TITLE
Enhancement: Dynamic pagination based on window width

### DIFF
--- a/plugins/plugin-site/src/components/Pages.jsx
+++ b/plugins/plugin-site/src/components/Pages.jsx
@@ -8,18 +8,19 @@ export default class Pages extends React.PureComponent {
         current: PropTypes.number.isRequired,
         pages: PropTypes.number.isRequired,
         pagesToDisplay: PropTypes.number.isRequired,
-        updatePage: PropTypes.func.isRequired
+        updatePage: PropTypes.func.isRequired,
+        marginPagesDisplayed: PropTypes.number.isRequired
     };
 
     render() {
-        const {updatePage, current, pages} = this.props;
+        const {updatePage, current, pages, marginPagesDisplayed} = this.props;
         const handlePageClick = (data) => updatePage(data.selected + 1);
 
         return (
             <ReactPaginate
                 pageCount={pages - 1}
                 pageRangeDisplayed={this.props.pagesToDisplay}
-                marginPagesDisplayed={2}
+                marginPagesDisplayed={marginPagesDisplayed}
                 onPageChange={handlePageClick}
                 forcePage={current - 1}
 

--- a/plugins/plugin-site/src/components/Pages.jsx
+++ b/plugins/plugin-site/src/components/Pages.jsx
@@ -27,7 +27,7 @@ export default class Pages extends React.PureComponent {
                 breakClassName={'page-item disabled'}
                 breakLinkClassName={'page-link'}
 
-                pageClassName={'page-item d-none d-sm-block'}
+                pageClassName={'page-item'}
                 pageLinkClassName={'page-link'}
                 nextClassName={'page-item'}
                 nextLinkClassName={'page-link'}

--- a/plugins/plugin-site/src/components/Pagination.jsx
+++ b/plugins/plugin-site/src/components/Pagination.jsx
@@ -5,6 +5,7 @@ import Pages from './Pages';
 
 function Pagination({limit, page, pages, total, setPage}) {
     const [pagesToDisplay, setPagesToDisplay] = React.useState(5);
+    const [marginPagesDisplayed, setMarginPagesDisplayed] = React.useState(2);
 
     if (total == 0) {
         return null;
@@ -15,14 +16,17 @@ function Pagination({limit, page, pages, total, setPage}) {
 
     React.useEffect(() => {
         if (window.innerWidth < 768) {
-            setPagesToDisplay(2);
+            setPagesToDisplay(1);
+            setMarginPagesDisplayed(1);
         }
 
         const handleWindowResize = () => {
             if (window.innerWidth < 768) {
-                setPagesToDisplay(2);
+                setPagesToDisplay(1);
+                setMarginPagesDisplayed(1);
             } else {
                 setPagesToDisplay(5);
+                setMarginPagesDisplayed(2);
             }
         };
 
@@ -41,6 +45,7 @@ function Pagination({limit, page, pages, total, setPage}) {
                     pages={pages}
                     pagesToDisplay={pagesToDisplay}
                     updatePage={setPage}
+                    marginPagesDisplayed={marginPagesDisplayed}
                 />
             }
         </>

--- a/plugins/plugin-site/src/components/Pagination.jsx
+++ b/plugins/plugin-site/src/components/Pagination.jsx
@@ -15,13 +15,13 @@ function Pagination({limit, page, pages, total, setPage}) {
     const end = Math.min(limit * (page), total);
 
     React.useEffect(() => {
-        if (window.innerWidth < 768) {
+        if (window.innerWidth < 576) {
             setPagesToDisplay(1);
             setMarginPagesDisplayed(1);
         }
 
         const handleWindowResize = () => {
-            if (window.innerWidth < 768) {
+            if (window.innerWidth < 576) {
                 setPagesToDisplay(1);
                 setMarginPagesDisplayed(1);
             } else {

--- a/plugins/plugin-site/src/components/Pagination.jsx
+++ b/plugins/plugin-site/src/components/Pagination.jsx
@@ -4,12 +4,31 @@ import Pages from './Pages';
 
 
 function Pagination({limit, page, pages, total, setPage}) {
+    const [pagesToDisplay, setPagesToDisplay] = React.useState(5);
+
     if (total == 0) {
         return null;
     }
 
     const start = (limit * (page - 1));
     const end = Math.min(limit * (page), total);
+
+    React.useEffect(() => {
+        if (window.innerWidth < 768) {
+            setPagesToDisplay(2);
+        }
+
+        const handleWindowResize = () => {
+            if (window.innerWidth < 768) {
+                setPagesToDisplay(2);
+            } else {
+                setPagesToDisplay(5);
+            }
+        };
+
+        window.addEventListener('resize', handleWindowResize);
+        return () => window.removeEventListener('resize', handleWindowResize);
+    }, []);
 
     return (
         <>
@@ -20,7 +39,7 @@ function Pagination({limit, page, pages, total, setPage}) {
                 <Pages
                     current={page}
                     pages={pages}
-                    pagesToDisplay={5}
+                    pagesToDisplay={pagesToDisplay}
                     updatePage={setPage}
                 />
             }


### PR DESCRIPTION
- Set the default value of pagesToDisplay to 5 which was already hard coded
- Implemented dynamic changing of pagesToDisplay based on window width
- If window width is less than 768px, pagesToDisplay is set to 2, otherwise it's set to 5
- Added a window resize event listener to update pagesToDisplay value dynamically
- Tested the implementation on various window widths and it's working as expected

Before
![image](https://user-images.githubusercontent.com/62999423/216619109-cb899d28-8ff1-488a-88db-130691ec0e38.png)

After Fix
![image](https://user-images.githubusercontent.com/62999423/216619301-81b96320-1ac9-4431-a72b-6ef383b9a97d.png)
