### PR TITLE
Fix renovate configuration to keep `docker-builder` version up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,16 +11,10 @@
     },
     "regexManagers": [
         {
-            "fileMatch": [
-                "^Jenkinsfile$",
-                "^Jenkinsfile_k8s$"
-            ],
-            "matchStrings": [
-                "image '(?<depName>[a-z/-]+):(?<currentValue>[a-z0-9.-]+)@(?<currentDigest>sha256:[a-f0-9]+)'",
-                "image: \"(?<depName>[a-z/-]+):(?<currentValue>[a-z0-9.-]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
-            ],
-            "datasourceTemplate": "docker",
-            "versioningTemplate": "docker"
+            "fileMatch": ["Jenkinsfile_k8s"],
+            "matchStrings": ["image: \"jenkinsciinfra/builder:(?<currentValue>.*?)\"\n"],
+            "depNameTemplate": "jenkinsciinfra/builder",
+            "datasourceTemplate": "docker"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
The image isn't used anymore (?) in Jenkinsfile, and its current version in Jenkinsfile_k8s is outdated.

I've reused the corresponding [jenkins.io renovate config section](https://github.com/jenkins-infra/jenkins.io/blob/adac4f646644a29e30aec01cf4f5688eb7c52d6b/renovate.json#L37-L42).