### PR TITLE
Revert "Fix renovate configuration to keep `docker-builder` version up to date"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,16 @@
     },
     "regexManagers": [
         {
-            "fileMatch": ["Jenkinsfile_k8s"],
-            "matchStrings": ["image: \"jenkinsciinfra/builder:(?<currentValue>.*?)\"\n"],
-            "depNameTemplate": "jenkinsciinfra/builder",
-            "datasourceTemplate": "docker"
+            "fileMatch": [
+                "^Jenkinsfile$",
+                "^Jenkinsfile_k8s$"
+            ],
+            "matchStrings": [
+                "image '(?<depName>[a-z/-]+):(?<currentValue>[a-z0-9.-]+)@(?<currentDigest>sha256:[a-f0-9]+)'",
+                "image: \"(?<depName>[a-z/-]+):(?<currentValue>[a-z0-9.-]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+            ],
+            "datasourceTemplate": "docker",
+            "versioningTemplate": "docker"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
Reverts jenkins-infra/plugin-site#1278

I misunderstood how renovate was working, the docker-builder update was already present in #860 but unchecked, it isn't anymore, reverting my previous PR.