### PR TITLE
Revert "chore(deps): update jenkinsciinfra/builder docker tag to v2.2.12" (#1284

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ spec:
   automountServiceAccountToken: false
   containers:
     - name: "jnlp"
-      image: "jenkinsciinfra/builder:2.2.12@sha256:0da4735f2648904366c90643cd0f67a17ed91d266659839ffee3f4ccb1a50794"
+      image: "jenkinsciinfra/builder:2.0.55@sha256:77dd8139b078d307e3dcb7f68dbf6d57b357776229ccaafb93cbb5a54a07d349"
       resources:
         limits: {}
         requests:


### PR DESCRIPTION
Reverts jenkins-infra/plugin-site#1280

Quoting myself from #1280

> Any idea how/why renovate merged this PR alone while the build of the 992725a commit is marked as failed?
> 
> I've ticket the "If you want to rebase/retry this PR, check this box" checkbox yesterday but didn't expected a merge as a result 🙁 
> 
> Anyway, it broke the builds, reverting.

