### PR TITLE
Remove redundant .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,10 +107,7 @@ public/
 # End of https://www.gitignore.io/api/node
 
 .cache/
-public/
 
-src/layout.jsx
-src/layout.css
 netlifyctl
 junit.xml
 yarn-error.log
@@ -118,4 +115,3 @@ yarn-error.log
 # IDE
 .idea
 static/site.webmanifest
-schema.graphql


### PR DESCRIPTION
Some of the files only exist in subfolder and are ignored by the .gitignore in plugins/plugin-site.
The public folder was ignored twice.