### PR TITLE
Update Gitter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jenkins Plugin Site
 
-[![Join the chat at https://gitter.im/jenkinsci/docs](https://badges.gitter.im/jenkinsci/docs.svg)](https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://app.gitter.im/#/room/#jenkins/docs:matrix.org](https://badges.gitter.im/jenkinsci/docs.svg)](https://gitter.im/jenkinsci/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GitHub release](https://img.shields.io/github/release/jenkins-infra/plugin-site.svg?label=changelog)](https://github.com/jenkins-infra/plugin-site/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkinsciinfra/plugin-site?label=jenkinsciinfra%2Fplugin-site&logo=docker&logoColor=white)](https://hub.docker.com/r/jenkinsciinfra/plugin-site)
 


### PR DESCRIPTION
Since yesterday, February the 13th, Gitter migrated to matrix. Existing links are redirected, but some redirections broke or use a different URL.
This PR updates the link to use the final destination, to ensure we don't rely on possible breaking redirections.