### PR TITLE
chore: add dependabot to ensure GitHub actions are tracked

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3355