### PR TITLE
fix plugin page tab urls so they get matched and marked active properly

### DIFF
--- a/plugins/plugin-site/src/components/PluginPageLayout.jsx
+++ b/plugins/plugin-site/src/components/PluginPageLayout.jsx
@@ -31,10 +31,10 @@ function shouldShowGitHubUrl({url}) {
 
 function PluginPageLayout({plugin, children}) {
     const tabs = [
-        {id: 'documentation', to: `/${plugin.name}`, label: 'Documentation'},
-        {id: 'releases', to: `/${plugin.name}/releases`, label: 'Releases'},
-        {id: 'issues', to: `/${plugin.name}/issues`, label: 'Issues'},
-        {id: 'dependencies', to: `/${plugin.name}/dependencies`, label: 'Dependencies'},
+        {id: 'documentation', to: `/${plugin.name}/`, label: 'Documentation'},
+        {id: 'releases', to: `/${plugin.name}/releases/`, label: 'Releases'},
+        {id: 'issues', to: `/${plugin.name}/issues/`, label: 'Issues'},
+        {id: 'dependencies', to: `/${plugin.name}/dependencies/`, label: 'Dependencies'},
     ];
 
     const [isShowInstructions, setShowInstructions] = React.useState(false);

--- a/plugins/plugin-site/src/components/PluginPageTabs.jsx
+++ b/plugins/plugin-site/src/components/PluginPageTabs.jsx
@@ -3,26 +3,13 @@ import PropTypes from 'prop-types';
 
 import {Link} from 'gatsby';
 
-const PluginPageTabs = ({ tabs }) => {
-
-    let isAnyTabActive = false;
-    tabs.forEach((tab) => {
-        if (window.location.pathname === tab.to) {
-            isAnyTabActive = true;
-        }
-    });
-
+const PluginPageTabs = ({tabs}) => {
     return (
         <ul className="nav nav-pills">
-            {tabs.map((tab, index) => {
+            {tabs.map(tab => {
                 return (
                     <li className="nav-item" key={tab.id}>
-                        <Link
-                            activeClassName="active"
-                            className={`nav-link ${!isAnyTabActive && index === 0 ? "active" : ""}`} 
-                            to={tab.to}>
-                            {tab.label}
-                        </Link>
+                        <Link activeClassName="active" className="nav-link" to={tab.to}>{tab.label}</Link>
                     </li>
                 );
             })}
@@ -32,9 +19,9 @@ const PluginPageTabs = ({ tabs }) => {
 PluginPageTabs.displayName = 'PluginPageTabs';
 PluginPageTabs.propTypes = {
     tabs: PropTypes.arrayOf(PropTypes.shape({
-            id: PropTypes.string.isRequired,
-            to: PropTypes.string.isRequired,
-            label: PropTypes.string.isRequired,
+        id: PropTypes.string.isRequired,
+        to: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
     }))
 };
 

--- a/plugins/plugin-site/src/components/PluginPageTabs.jsx
+++ b/plugins/plugin-site/src/components/PluginPageTabs.jsx
@@ -3,13 +3,26 @@ import PropTypes from 'prop-types';
 
 import {Link} from 'gatsby';
 
-const PluginPageTabs = ({tabs}) => {
+const PluginPageTabs = ({ tabs }) => {
+
+    let isAnyTabActive = false;
+    tabs.forEach((tab) => {
+        if (window.location.pathname === tab.to) {
+            isAnyTabActive = true;
+        }
+    });
+
     return (
         <ul className="nav nav-pills">
-            {tabs.map(tab => {
+            {tabs.map((tab, index) => {
                 return (
                     <li className="nav-item" key={tab.id}>
-                        <Link activeClassName="active" className="nav-link" to={tab.to}>{tab.label}</Link>
+                        <Link
+                            activeClassName="active"
+                            className={`nav-link ${!isAnyTabActive && index === 0 ? "active" : ""}`} 
+                            to={tab.to}>
+                            {tab.label}
+                        </Link>
                     </li>
                 );
             })}
@@ -19,9 +32,9 @@ const PluginPageTabs = ({tabs}) => {
 PluginPageTabs.displayName = 'PluginPageTabs';
 PluginPageTabs.propTypes = {
     tabs: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        to: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
+            id: PropTypes.string.isRequired,
+            to: PropTypes.string.isRequired,
+            label: PropTypes.string.isRequired,
     }))
 };
 


### PR DESCRIPTION
![up1](https://user-images.githubusercontent.com/101264150/224145111-75d61ce3-1e07-483a-bafd-7f1bf2be7fdd.PNG)
**Before Change**: This is how it currently looks, it doesn't show the current tab as of documentation.

![up2](https://user-images.githubusercontent.com/101264150/224145513-ad5b8603-7049-45d9-8db8-a8404d174f6b.PNG)
**After Change**: After making some changes it now show as the current tab as of documentation if no tabs are selected.