### PR TITLE
Handle build number when sorting builds

### DIFF
--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.js
@@ -37,7 +37,7 @@ exports.createSchemaCustomization = ({actions}) => {
                     // 2.29 => s00002_s00029_s00000
                     // 2.290 => s00002_s00290_s00000
                     // 2.290-rc4 => s00002_s00290_r00004
-                    return padArrayEnd(value.split(/[.-]/), 4, 0).map(val => getQualifier(val)
+                    return padArrayEnd(value.split(/\+build\.|[.-]/), 4, 0).map(val => getQualifier(val)
                                 + val.toString().replace(/^rc/, '').replace(/^[ab](\d)/, '$1').padStart(5, '0')).join('_');
                 },
             };

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
@@ -19,7 +19,8 @@ describe('gatsby-node', () => {
         });
         describe('machineVersion', () => {
             const versions = ['0.1', '1.0-b9', '1.0-b10', '1.0-rc2', '1.0', '1.0.9', '1.0.10',
-                '1.0.10-2', '1.1', '2.0', '4.7.1.1'];
+                '1.0.10-2', '1.1', '1.9+build.201606131328', '1.13+build.202205140447',
+                 '1.14-651.v429b_16b_db_60e', '2.0', '4.7.1.1'];
             for (let idx = 1; idx < versions.length; idx++) {
                 it (`Version ${versions[idx - 1]} should be less than ${versions[idx]}`, () => {
                     const oldVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx - 1]});

--- a/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
+++ b/plugins/gatsby-jenkinsci-fieldextensions/gatsby-node.test.js
@@ -20,7 +20,7 @@ describe('gatsby-node', () => {
         describe('machineVersion', () => {
             const versions = ['0.1', '1.0-b9', '1.0-b10', '1.0-rc2', '1.0', '1.0.9', '1.0.10',
                 '1.0.10-2', '1.1', '1.9+build.201606131328', '1.13+build.202205140447',
-                 '1.14-651.v429b_16b_db_60e', '2.0', '4.7.1.1'];
+                '1.14-651.v429b_16b_db_60e', '2.0', '4.7.1.1'];
             for (let idx = 1; idx < versions.length; idx++) {
                 it (`Version ${versions[idx - 1]} should be less than ${versions[idx]}`, () => {
                     const oldVal = fieldExtensions.machineVersion({field: 'version'}).resolve({version: versions[idx - 1]});


### PR DESCRIPTION
fixes most recent build not showing up on https://plugins.jenkins.io/build-monitor-plugin/releases