### PR TITLE
more fixes toward standarizing everything with slashes

### DIFF
--- a/plugins/plugin-site/gatsby-browser.js
+++ b/plugins/plugin-site/gatsby-browser.js
@@ -1,12 +1,12 @@
 exports.onClientEntry = function () {
     if (window.location.hash === '#releases') {
-        window.location.href = `/${window.location.pathname.split('/')[1]}/releases`;
+        window.location.href = `/${window.location.pathname.split('/')[1]}/releases/`;
     }
     else if (window.location.hash === '#issues') {
-        window.location.href = `/${window.location.pathname.split('/')[1]}/issues`;
+        window.location.href = `/${window.location.pathname.split('/')[1]}/issues/`;
     }
     else if (window.location.hash === '#dependencies') {
-        window.location.href = `/${window.location.pathname.split('/')[1]}/dependencies`;
+        window.location.href = `/${window.location.pathname.split('/')[1]}/dependencies/`;
     }
 
     require.ensure(['@sentry/browser'], (require) => {

--- a/plugins/plugin-site/gatsby-node.js
+++ b/plugins/plugin-site/gatsby-node.js
@@ -31,21 +31,21 @@ async function createPluginPages({graphql, createPage}) {
             }
         });
         createPage({
-            path: `/${edge.node.name.trim()}/releases`,
+            path: `/${edge.node.name.trim()}/releases/`,
             component: templatesPluginReleases,
             context: {
                 name: edge.node.name.trim()
             }
         });
         createPage({
-            path: `/${edge.node.name.trim()}/issues`,
+            path: `/${edge.node.name.trim()}/issues/`,
             component: templatesPluginIssues,
             context: {
                 name: edge.node.name.trim()
             }
         });
         createPage({
-            path: `/${edge.node.name.trim()}/dependencies`,
+            path: `/${edge.node.name.trim()}/dependencies/`,
             component: templatesPluginDependencies,
             context: {
                 name: edge.node.name.trim()

--- a/plugins/plugin-site/src/components/InstallInstructions.jsx
+++ b/plugins/plugin-site/src/components/InstallInstructions.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {navigate} from 'gatsby';
 import {Modal, ModalHeader, ModalBody} from 'reactstrap';
 import InstallViaCLI from './InstallViaCLI';
 
@@ -25,7 +26,7 @@ function InstallInstructions({isShowInstructions, toggleShowInstructions, plugin
                             {'Using direct upload'}
                         </a>
                         {'. Download one of the '}
-                        <a href="#releases" onClick={e=>{toggleShowInstructions(e);location.href='#releases';}}>
+                        <a href="#releases" onClick={e=>{toggleShowInstructions(e);navigate(`/${pluginId}/releases/`);}}>
                             {'releases'}
                         </a>
                         {' and upload it to your Jenkins instance.'}


### PR DESCRIPTION
client side is redirecting plugins.jenkins.io/script-security/releases/ to plugins.jenkins.io/script-security/releases
I think its the createPage thingie (i think netlify plugin, when we have the netlify flag set, overrides it)
so just add slashes everywhere

I can't wait till we can fully netlify this