### PR TITLE
Handle maintainer filter and tag clicks in search results

### DIFF
--- a/plugins/plugin-site/src/components/FiltersHooks.jsx
+++ b/plugins/plugin-site/src/components/FiltersHooks.jsx
@@ -11,7 +11,7 @@ const DEFAULT_DATA = {
     page: 1,
 };
 
-function useFilterHooks({doSearch, setResults, categoriesMap}) {
+function useFilterHooks() {
     const [data, setData] = React.useState(DEFAULT_DATA);
 
     const ret = {
@@ -41,7 +41,6 @@ function useFilterHooks({doSearch, setResults, categoriesMap}) {
             }
             navigate(`/ui/search?${querystring.stringify({...newData})}`);
             ret.setData(newData);
-            doSearch(newData, setResults, categoriesMap);
         };
     });
 

--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Link} from 'gatsby';
+import {navigate} from 'gatsby';
 
 import {cleanTitle} from '../commons/helper';
 import Icon from '../components/Icon';
@@ -26,7 +26,7 @@ Developers.propTypes = PluginDevelopers.propTypes;
 
 function Plugin({plugin: {name, title, stats, labels, excerpt, developers, buildDate, releaseTimestamp}}) {
     return (
-        <Link to={`/${name}/`} className="Plugin--PluginContainer">
+        <div onClick={() => navigate(`/${name}/`)} className="Plugin--PluginContainer">
             <div className="Plugin--IconContainer">
                 <Icon title={title} />
             </div>
@@ -49,7 +49,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
             <div className="Plugin--AuthorsContainer">
                 <Developers developers={developers} />
             </div>
-        </Link>
+        </div>
     );
 }
 
@@ -71,9 +71,6 @@ Plugin.propTypes = {
         }).isRequired,
         title: PropTypes.string.isRequired,
         version: PropTypes.string,
-        wiki: PropTypes.shape({
-            url: PropTypes.string
-        }).isRequire,
     }).isRequired
 };
 

--- a/plugins/plugin-site/src/components/PluginDevelopers.jsx
+++ b/plugins/plugin-site/src/components/PluginDevelopers.jsx
@@ -7,7 +7,9 @@ function PluginDevelopers({developers}) {
         <>
             {developers.map((developer) => (
                 <div className="maintainer" key={developer.id}>
-                    <Link to={`/ui/search?query=${developer.id}`}>{developer.name || developer.id}</Link>
+                    <Link to={`/ui/search?query=${developer.id}`} onClick={e => e.stopPropagation()}>
+                        {developer.name || developer.id}
+                    </Link>
                 </div>
             ))}
         </>

--- a/plugins/plugin-site/src/components/PluginLabels.jsx
+++ b/plugins/plugin-site/src/components/PluginLabels.jsx
@@ -26,7 +26,7 @@ function PluginLabels({labels}) {
         const text = (allLabels[id] || id).replace(' development', '');
         return (
             <div className="label-link" key={id}>
-                <Link to={`/ui/search/?labels=${id}`}>{text}</Link>
+                <Link to={`/ui/search/?labels=${id}`} onClick={e => e.stopPropagation()}>{text}</Link>
             </div>
         );
     });

--- a/plugins/plugin-site/src/templates/search.jsx
+++ b/plugins/plugin-site/src/templates/search.jsx
@@ -104,7 +104,7 @@ function SearchPage({location}) {
         page, setPage,
         query, setQuerySilent, clearQuery,
         setData
-    } = useFilterHooks({doSearch, setResults, categoriesMap});
+    } = useFilterHooks();
 
     const handleOnSubmit = (e) => {
         const newData = {sort, categories, labels, view, page, query};

--- a/plugins/plugin-site/src/templates/search.jsx
+++ b/plugins/plugin-site/src/templates/search.jsx
@@ -110,18 +110,18 @@ function SearchPage({location}) {
         const newData = {sort, categories, labels, view, page, query};
         e.preventDefault();
         navigate(`/ui/search?${querystring.stringify(newData)}`);
-        doSearch(newData, setResults, categoriesMap);
     };
 
     const searchPage = 'plugins/plugin-site/src/templates/search.jsx';
 
+    // triggered on page load and when intenal <Link> clicked, e.g. for label
     React.useEffect(() => {
         const qs = location.search.replace(/^\?/, '');
         const parsed = querystring.parse(qs);
         parsed.query = parsed.query || '';
         setData(parsed);
         doSearch(parsed, setResults, categoriesMap);
-    }, []);
+    }, [location]);
 
     return (
         <Layout id="searchpage" sourcePath={searchPage}>

--- a/plugins/plugin-site/src/templates/search.jsx
+++ b/plugins/plugin-site/src/templates/search.jsx
@@ -114,7 +114,7 @@ function SearchPage({location}) {
 
     const searchPage = 'plugins/plugin-site/src/templates/search.jsx';
 
-    // triggered on page load and when intenal <Link> clicked, e.g. for label
+    // triggered on page load and when internal <Link> clicked, e.g. for label
     React.useEffect(() => {
         const qs = location.search.replace(/^\?/, '');
         const parsed = querystring.parse(qs);


### PR DESCRIPTION
Fixes #1318 -- stopPropagation prevents both outer and inner link from being handled, change from `Link` to `navigate` avoids error in console about links nested in links. Change of `useEffect` needed for the links to actually have any effect.