### PR TITLE
Move renovate and update 'stabilityDays' clause

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
         "dependencies"
     ],
     "npm": {
-        "stabilityDays": 1
+        "stabilityDays": 3
     },
     "regexManagers": [
         {


### PR DESCRIPTION
NPM allows unpublishing releases within 72h. For the unlikely case a maintainer decides to go this route, I propose to bump the 'stabilityDays' from 1 to 3, to prevent being stuck with dependencies you can no longer obtain.

I moved the config inside the `.github` folder too, given its for a GH app.