### PR TITLE
Update node image for pods

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -22,7 +22,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: "node"
-      image: "node:15"
+      image: "node:18"
       securityContext:
         privileged: false
       tty: true


### PR DESCRIPTION
We build with Node 18, therefore it makes sense to use node 18 here too.