### PR TITLE
Ban IE 11

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -14,7 +14,8 @@
                 "targets": {
                     "browsers": [
                         ">0.25%",
-                        "not dead"
+                        "not dead",
+                        "not IE 11"
                     ]
                 }
             }


### PR DESCRIPTION
IE 11 has been removed from our browser compatibility matrix past year, we can safely ignore it here too.