### PR TITLE
Show install numbers as percentages

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -447,15 +447,20 @@ export const fetchStats = async ({reporter, stats}) => {
         for (const pluginRow of pluginInstalls) {
             const [pluginName, installs] = csvParse(pluginRow);
             stats[pluginName] = stats[pluginName] || {installations: []};
-            stats[pluginName].installations[timeSpan - monthsAgo] = {timestamp: timestamp, total: installs};
+            stats[pluginName].installations[timeSpan - monthsAgo] = {
+                timestamp: timestamp,
+                total: installs,
+                percentage: installs * 100 / coreInstalls
+            };
         }
     }
     for (const pluginName of Object.keys(stats)) {
         for (let idx = 0; idx < timeSpan; idx++) {
             stats[pluginName].installations[idx] = stats[pluginName].installations[idx]
-                || {total: 0, timestamp: timestamps[idx]};
+                || {total: 0, timestamp: timestamps[idx], percentage: 0};
         }
         stats[pluginName].currentInstalls = stats[pluginName].installations[timeSpan - 1].total || 0;
+        stats[pluginName].currentInstallPercentage = stats[pluginName].installations[timeSpan - 1].percentage || 0;
     }
 };
 

--- a/plugins/plugin-site/__tests__/src/commons/helper.test.js
+++ b/plugins/plugin-site/__tests__/src/commons/helper.test.js
@@ -1,4 +1,4 @@
-import {cleanTitle} from '../../../src/commons/helper';
+import {cleanTitle, formatPercentage} from '../../../src/commons/helper';
 
 describe('helpers', () => {
     describe('cleanTitle', () => {
@@ -7,6 +7,18 @@ describe('helpers', () => {
         });
         it('undefined doesnt error', () => {
             expect(cleanTitle(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('formatPercentage', () => {
+        it('shows high percentages accurately', () => {
+            expect(formatPercentage(95.45)).toBe('95.5%');
+            expect(formatPercentage(1.234)).toBe('1.23%');
+        });
+
+        it('shows low percentage concisely', () => {
+            expect(formatPercentage(0.9577)).toBe('0.96%');
+            expect(formatPercentage(0.009577)).toBe('0.0096%');
         });
     });
 });

--- a/plugins/plugin-site/src/commons/helper.js
+++ b/plugins/plugin-site/src/commons/helper.js
@@ -6,6 +6,8 @@ export const formatter = buildFormatter(Object.assign(enStrings, {
     'weeks': '%d weeks',
 }));
 
+export const formatPercentage = (pct) => `${pct.toPrecision(pct < 1 ? 2 : 3) }%`;
+
 /* FIXME:
   This isn't the best way to do this, but plugins currently have a lot
   of repetitive goop in their titles.

--- a/plugins/plugin-site/src/components/LineChart.test.jsx
+++ b/plugins/plugin-site/src/components/LineChart.test.jsx
@@ -23,7 +23,7 @@ describe('lineChart', () => {
             {'timestamp': 1630454400000, 'total': 4726},
             {'timestamp': 1633046400000, 'total': 4647},
             {'timestamp': 1635724800000, 'total': 4704}
-        ];
+        ].map(inst => ({...inst, 'percentage': inst.total / 10000}));
         const {getByRole} = render(<LineChart installations={installations} />);
 
         expect(getByRole('img')).toBeTruthy();

--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -25,7 +25,7 @@ function Developers({developers}) {
 Developers.propTypes = PluginDevelopers.propTypes;
 
 function Plugin({plugin: {name, title, stats, labels, excerpt, developers, buildDate, releaseTimestamp, healthScore}}) {
-
+    const installStr = stats.currentInstallPercentage ? formatPercentage(stats.currentInstallPercentage) : '?';
     return (
         <div onClick={() => navigate(`/${name}/`)} className="Plugin--PluginContainer">
             <div className="Plugin--IconContainer">
@@ -35,8 +35,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
                 <h4>{cleanTitle(title)}</h4>
             </div>
             <div className="Plugin--InstallsContainer">
-                {'Installs:  '}
-                {stats.currentInstallPercentage ? formatPercentage(stats.currentInstallPercentage) : '?'}
+                {`Used by ${installStr} of instances`}
             </div>
             <div className="Plugin--VersionContainer">
                 <span className="jc">

--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -36,7 +36,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
             </div>
             <div className="Plugin--InstallsContainer">
                 {'Installs:  '}
-                {formatPercentage(stats.currentInstallPercentage)}
+                {stats.currentInstallPercentage ? formatPercentage(stats.currentInstallPercentage) : '?'}
             </div>
             <div className="Plugin--VersionContainer">
                 <span className="jc">

--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {navigate} from 'gatsby';
-import {cleanTitle} from '../commons/helper';
+import {cleanTitle, formatPercentage} from '../commons/helper';
 import Icon from '../components/Icon';
 import PluginLabels from '../components/PluginLabels';
 import PluginLastReleased from '../components/PluginLastReleased';
@@ -36,7 +36,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
             </div>
             <div className="Plugin--InstallsContainer">
                 {'Installs:  '}
-                {stats.currentInstalls}
+                {formatPercentage(stats.currentInstallPercentage)}
             </div>
             <div className="Plugin--VersionContainer">
                 <span className="jc">
@@ -74,7 +74,7 @@ Plugin.propTypes = {
         requiredCore: PropTypes.string,
         sha1: PropTypes.string,
         stats: PropTypes.shape({
-            currentInstalls: PropTypes.number
+            currentInstallPercentage: PropTypes.number
         }).isRequired,
         title: PropTypes.string.isRequired,
         version: PropTypes.string,

--- a/plugins/plugin-site/src/components/PluginPageLayout.jsx
+++ b/plugins/plugin-site/src/components/PluginPageLayout.jsx
@@ -80,7 +80,8 @@ function PluginPageLayout({plugin, children}) {
                     <div className="sidebarSection">
                         {plugin.stats && <h5>
                             {'Installs: '}
-                            <PluginReadableInstalls currentInstalls={plugin.stats.currentInstalls} />
+                            <PluginReadableInstalls currentInstalls={plugin.stats.currentInstalls}
+                                percentage={plugin.stats.currentInstallPercentage} />
                         </h5>}
                         <div className="chart">
                             <LineChart

--- a/plugins/plugin-site/src/components/PluginPageLayout.jsx
+++ b/plugins/plugin-site/src/components/PluginPageLayout.jsx
@@ -78,11 +78,8 @@ function PluginPageLayout({plugin, children}) {
                         {plugin.name}
                     </div>
                     <div className="sidebarSection">
-                        {plugin.stats && <h5>
-                            {'Installs: '}
-                            <PluginReadableInstalls currentInstalls={plugin.stats.currentInstalls}
-                                percentage={plugin.stats.currentInstallPercentage} />
-                        </h5>}
+                        <PluginReadableInstalls currentInstalls={plugin.stats.currentInstalls}
+                            percentage={plugin.stats.currentInstallPercentage} />
                         <div className="chart">
                             <LineChart
                                 installations={plugin.stats.installations}

--- a/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
+++ b/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {formatPercentage} from '../commons/helper';
 
-function PluginReadableInstalls({currentInstalls}) {
+function PluginReadableInstalls({currentInstalls, percentage}) {
     if (!currentInstalls && currentInstalls !== 0) {
         return <>No usage data available</>;
     }
-    return <>{new Intl.NumberFormat('en-US').format(currentInstalls)}</>;
+    return (<span title={`Total: ${new Intl.NumberFormat('en-US').format(currentInstalls)}`}>
+        {formatPercentage(percentage)}
+    </span>);
 }
 
 PluginReadableInstalls.propTypes = {
-    currentInstalls: PropTypes.number
+    currentInstalls: PropTypes.number,
+    percentage: PropTypes.number
 };
 
 export default PluginReadableInstalls;

--- a/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
+++ b/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
@@ -4,11 +4,11 @@ import {formatPercentage} from '../commons/helper';
 
 function PluginReadableInstalls({currentInstalls, percentage}) {
     if (!currentInstalls && currentInstalls !== 0) {
-        return <>No usage data available</>;
+        return <h5>No usage data available</h5>;
     }
-    return (<span title={`Total: ${new Intl.NumberFormat('en-US').format(currentInstalls)}`}>
-        {formatPercentage(percentage)}
-    </span>);
+    return (<h5 title={`Total: ${new Intl.NumberFormat('en-US').format(currentInstalls)}`}>
+        {`Installed on ${formatPercentage(percentage)} of\u{A0}instances`}
+    </h5>);
 }
 
 PluginReadableInstalls.propTypes = {

--- a/plugins/plugin-site/src/components/PluginReleases.jsx
+++ b/plugins/plugin-site/src/components/PluginReleases.jsx
@@ -48,9 +48,11 @@ function PluginReleases({pluginId, versions}) {
                         <div className="card-header">
                             <h5 className="card-title d-flex justify-content-between">
                                 <div className="d-flex align-items-center">
-                                    <a href={version.url}>{release.name && release.name != release.tagName ? release.name : version.version}</a>
+                                    <a href={version.url}>{release.name && release.name !== release.tagName ? release.name : version.version}</a>
                                     {release.bodyHTML && (<>
-                                        <a href={release.htmlURL} title="See the release on GitHub" className="github-icon d-flex"><ion-icon name="logo-github" /></a>
+                                        <a href={release.htmlURL} title="See the release on GitHub" aria-label="See the release on GitHub" className="github-icon d-flex">
+                                            <ion-icon name="logo-github" />
+                                        </a>
                                     </>)}
                                     <a className="anchor after" href={`#version_${version.version}`}>
                                         <ion-icon name="link-outline"/>

--- a/plugins/plugin-site/src/fragments.js
+++ b/plugins/plugin-site/src/fragments.js
@@ -17,9 +17,11 @@ export const PluginFragment = graphql`
     }
     stats {
       currentInstalls
+      currentInstallPercentage
       installations {
           timestamp
           total
+          percentage
       }
       trend
     }

--- a/plugins/plugin-site/src/proptypes.js
+++ b/plugins/plugin-site/src/proptypes.js
@@ -42,7 +42,8 @@ export const PropTypesJenkinsPlugin = PropTypes.shape({
         currentInstalls: PropTypes.number,
         installations: PropTypes.arrayOf(PropTypes.shape({
             timestamp: PropTypes.number,
-            total: PropTypes.number
+            total: PropTypes.number,
+            percentage: PropTypes.number
         }))
     }).isRequired,
     title: PropTypes.string.isRequired,

--- a/plugins/plugin-site/src/templates/plugin_dependencies.test.jsx
+++ b/plugins/plugin-site/src/templates/plugin_dependencies.test.jsx
@@ -15,7 +15,8 @@ describe('component - TemplatePluginDependencies', () => {
             developers: [],
             stats: {
                 installations: [],
-                currentInstalls: 15
+                currentInstalls: 15,
+                currentInstallPercentage: 0.15
             },
             gav: 'something',
             dependencies: [],

--- a/plugins/plugin-site/src/templates/plugin_documentation.test.jsx
+++ b/plugins/plugin-site/src/templates/plugin_documentation.test.jsx
@@ -15,7 +15,8 @@ describe('component - TemplatePluginDocumentation', () => {
             developers: [],
             stats: {
                 installations: [],
-                currentInstalls: 15
+                currentInstalls: 15,
+                currentInstallPercentage: 15,
             },
             gav: 'something',
             dependencies: [],

--- a/plugins/plugin-site/src/templates/plugin_issues.test.jsx
+++ b/plugins/plugin-site/src/templates/plugin_issues.test.jsx
@@ -15,7 +15,8 @@ describe('component - TemplatePluginIssues', () => {
             developers: [],
             stats: {
                 installations: [],
-                currentInstalls: 15
+                currentInstalls: 15,
+                currentInstallPercentage: 0.15,
             },
             gav: 'something',
             dependencies: [],

--- a/plugins/plugin-site/src/templates/plugin_releases.test.jsx
+++ b/plugins/plugin-site/src/templates/plugin_releases.test.jsx
@@ -15,7 +15,8 @@ describe('component - TemplatePluginReleases', () => {
             developers: [],
             stats: {
                 installations: [],
-                currentInstalls: 15
+                currentInstalls: 15,
+                currentInstallPercentage: 0.15,
             },
             gav: 'something',
             dependencies: [],

--- a/plugins/plugin-site/src/utils/algolia-queries.mjs
+++ b/plugins/plugin-site/src/utils/algolia-queries.mjs
@@ -9,7 +9,7 @@ function pluginQueries() {
             excerpt
             labels
             stats {
-              currentInstalls
+              currentInstallPercentage
               trend
             }
             healthScore {


### PR DESCRIPTION
Fixes #1238

@daniel-beck one difference to your proposal: precision for big percentages is 3 significant digits (to avoid 12 identical values in graph tooltips). For small percentages I kept the proposed 2 digits (the 3rd digit might otherwise represent less than 1 user).