### PR TITLE
hotfix(Jenkinsfile_k8s) fix PATH to allow `blobxfer` execution with the v3 image

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -49,6 +49,8 @@ spec:
     TZ = "UTC"
     GET_CONTENT = "true"
     NODE_ENV = "production"
+    ## TODO: Remove this "custom PATH" once https://github.com/jenkins-infra/docker-builder/blob/e5749f5cf0392549a89ba3a5b41a41fe55ec48dd/Dockerfile#L46 is updated to persist it
+    PATH = "/home/jenkins/.local/bin:${env.PATH}"
   }
 
   triggers {


### PR DESCRIPTION
As caught by @lemeurherve , the builds are failing to execute `blobxfer` since https://github.com/jenkins-infra/plugin-site/pull/1514 (as blobxfer is now [installed with pipx](https://github.com/jenkins-infra/docker-builder/pull/166)).


Ping @NotMyFault @timja do you now if we can avoid the automerge of renovabot PR when there is a major change for the docker-builder image (as we can't run a PR check for this)?
