### PR TITLE
fix: remove unnecessary `NETLIFY` env var to restore infra.ci.jenkins.io builds

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -83,7 +83,6 @@ spec:
         DISABLE_SEARCH_ENGINE = "true"
         GATSBY_ALGOLIA_APP_ID = credentials('algolia-plugins-app-id')
         GATSBY_ALGOLIA_SEARCH_KEY = credentials('algolia-plugins-search-key')
-        NETLIFY = "true"
       }
       steps {
         sh 'yarn build'


### PR DESCRIPTION
As commented by @halkeye in https://github.com/jenkins-infra/helpdesk/issues/3816#issuecomment-1823220807,

> [`NETLIFY` env var] is actually just a variable to make a netlify banner show up, which isn't even a requirement for the free stuff they provided, you can just remove the env variable.

This PR removes it to restore builds and previews from infra.ci.jenkins.io

Fixes https://github.com/jenkins-infra/helpdesk/issues/3816#issuecomment-1823220737