### PR TITLE
chore: use exponential delay when axios retries requests

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -22,7 +22,7 @@ import findPackageJson from 'find-package-json';
 
 const API_URL = process.env.JENKINS_IO_API_URL || 'https://plugins.jenkins.io/api';
 
-axiosRetry(axios, {retries: 3, retryDelay: axiosRetry.exponentialDelay});
+axiosRetry(axios, {retries: 5, retryDelay: axiosRetry.exponentialDelay});
 
 const requestGET = async ({url, reporter}) => {
     const activity = reporter.activityTimer(`Fetching '${url}'`);

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -22,7 +22,7 @@ import findPackageJson from 'find-package-json';
 
 const API_URL = process.env.JENKINS_IO_API_URL || 'https://plugins.jenkins.io/api';
 
-axiosRetry(axios, {retries: 3});
+axiosRetry(axios, {retries: 3, retryDelay: axiosRetry.exponentialDelay});
 
 const requestGET = async ({url, reporter}) => {
     const activity = reporter.activityTimer(`Fetching '${url}'`);

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -4,7 +4,7 @@ import path from 'path';
 import crypto from 'crypto';
 import {load} from 'cheerio';
 import {execSync} from 'child_process';
-import axiosRetry from 'axios-retry';
+import axiosRetry, {exponentialDelay} from 'axios-retry';
 import {parse as parseDate} from 'date-fns';
 import PQueue from 'p-queue';
 import {parseStringPromise} from 'xml2js';
@@ -22,7 +22,7 @@ import findPackageJson from 'find-package-json';
 
 const API_URL = process.env.JENKINS_IO_API_URL || 'https://plugins.jenkins.io/api';
 
-axiosRetry(axios, {retries: 5, retryDelay: axiosRetry.exponentialDelay});
+axiosRetry(axios, {retries: 5, retryDelay: exponentialDelay});
 
 const requestGET = async ({url, reporter}) => {
     const activity = reporter.activityTimer(`Fetching '${url}'`);

--- a/plugins/gatsby-source-jenkinsplugins/utils.test.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.test.mjs
@@ -101,7 +101,7 @@ describe('utils', () => {
         };
         await fetchPluginData({createNode, createNodeId, createContentDigest, reporter: _reporter, firstReleases, labelToCategory, stats});
         expect(createNode.mock.calls.filter(call => call[0].name === 'ios-device-connector').map(args => args[0])).toMatchSnapshot();
-    });
+    }, 15000);
     it('get plugin healthScore data', async () => {
         nock('https://plugin-health.jenkins.io')
             .get('/api/scores')


### PR DESCRIPTION
As mentionned by @slide and @uhafner in gitter/matrix channels, there has been issues with the https://plugins.jenkins.io/token-macro/ page not showing the proper readme page which is unexpected.

While searching for this, it appeared that there are a lot of network error on the node http.js client side like the following:

```text
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]: error error trying to fetch https://plugins.jenkins.io/api/plugin/kubernetes-credentials-provider 
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]: 
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]: 
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   AggregateError: 
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - AxiosError.js:89 Function.AxiosError.from
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     [website-jobs_plugin-site_master]/[axios]/lib/core/AxiosError.js:89:14
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - http.js:606 RedirectableRequest.handleRequestError
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     [website-jobs_plugin-site_master]/[axios]/lib/adapters/http.js:606:25
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - node:events:514 RedirectableRequest.emit
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:events:514:28
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - index.js:14 ClientRequest.eventHandlers.<computed>
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     [website-jobs_plugin-site_master]/[follow-redirects]/index.js:14:24
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - node:events:514 ClientRequest.emit
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:events:514:28
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - node:_http_client:495 TLSSocket.socketErrorListener
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:_http_client:495:9
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - node:events:514 TLSSocket.emit
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:events:514:28
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - destroy:151 emitErrorNT
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:internal/streams/destroy:151:8
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - destroy:116 emitErrorCloseNT
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:internal/streams/destroy:116:3
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:   - task_queues:82 processTicksAndRejections
➤ YN0000: [@jenkins-cd/jenkins-plugin-site]:     node:internal/process/task_queues:82:21
```

Even though there is a retry at `3`, this PR is a short term fix to:

- Retry more often (5 times instead of 3 as pointed out by @lemeurherve ❤️ )
- Add an exponential backof for retries to let the HTTP client breathe a little (ref. https://www.npmjs.com/package/axios-retry/v/3.8.0)