### PR TITLE
Display score resolution help when available

### DIFF
--- a/plugins/plugin-site/src/components/PluginHealthScore.jsx
+++ b/plugins/plugin-site/src/components/PluginHealthScore.jsx
@@ -16,7 +16,27 @@ ScoreValue.propTypes = {
     value: PropTypes.number.isRequired,
 };
 
-function ScoreComponent({component: {value, reasons}}) {
+function ScoreResolutions({resolutions}) {
+    return (
+        <div className="pluginHealth--score-component--resolutions">
+            <ul>
+                {resolutions.map((resolution, idx) => {
+                    return (
+                        <li key={idx}>
+                            <a href={resolution}>{resolution}</a>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}
+
+ScoreResolutions.propTypes = {
+    resolutions: PropTypes.arrayOf(PropTypes.string),
+};
+
+function ScoreComponent({component: {value, reasons, resolutions}}) {
     return (
         <div className="pluginHealth--score-component">
             <div className="pluginHealth--score-component--reasons">
@@ -25,6 +45,7 @@ function ScoreComponent({component: {value, reasons}}) {
                         <span key={idx}>{reason}</span>
                     );
                 })}
+                {resolutions.length > 0 && <ScoreResolutions resolutions={resolutions} />}
             </div>
             <ScoreValue value={value} />
         </div>
@@ -36,6 +57,7 @@ ScoreComponent.propTypes = {
         value: PropTypes.number.isRequired,
         weight: PropTypes.number.isRequired,
         reasons: PropTypes.arrayOf(PropTypes.string),
+        resolutions: ScoreResolutions.propTypes.resolutions,
     }).isRequired
 };
 

--- a/plugins/plugin-site/src/components/PluginHealthScore.jsx
+++ b/plugins/plugin-site/src/components/PluginHealthScore.jsx
@@ -23,7 +23,7 @@ function ScoreResolutions({resolutions}) {
                 {resolutions.map((resolution, idx) => {
                     return (
                         <li key={idx}>
-                            <a href={resolution}>{resolution}</a>
+                            <a href={resolution.link}>{resolution.text}</a>
                         </li>
                     );
                 })}
@@ -33,7 +33,10 @@ function ScoreResolutions({resolutions}) {
 }
 
 ScoreResolutions.propTypes = {
-    resolutions: PropTypes.arrayOf(PropTypes.string),
+    resolutions: PropTypes.arrayOf(PropTypes.shape({
+        text: PropTypes.string,
+        link: PropTypes.string,
+    })),
 };
 
 function ScoreComponent({component: {value, reasons, resolutions}}) {

--- a/plugins/plugin-site/src/templates/plugin_healthScore.jsx
+++ b/plugins/plugin-site/src/templates/plugin_healthScore.jsx
@@ -25,6 +25,7 @@ TemplatePluginHealthScore.propTypes = {
                     max: PropTypes.number.isRequired,
                     value: PropTypes.number.isRequired,
                     reasons: PropTypes.arrayOf(PropTypes.string).isRequired,
+                    resolutions: PropTypes.arrayOf(PropTypes.string),
                 })).isRequired,
                 name: PropTypes.string.isRequired,
                 value: PropTypes.number.isRequired,
@@ -47,6 +48,7 @@ export const pageQuery = graphql`
                     weight
                     value
                     reasons
+                    resolutions
                 }
                 name
                 value

--- a/plugins/plugin-site/src/templates/plugin_healthScore.jsx
+++ b/plugins/plugin-site/src/templates/plugin_healthScore.jsx
@@ -25,7 +25,10 @@ TemplatePluginHealthScore.propTypes = {
                     max: PropTypes.number.isRequired,
                     value: PropTypes.number.isRequired,
                     reasons: PropTypes.arrayOf(PropTypes.string).isRequired,
-                    resolutions: PropTypes.arrayOf(PropTypes.string),
+                    resolutions: PropTypes.arrayOf(PropTypes.shape({
+                        text: PropTypes.string,
+                        link: PropTypes.string,
+                    })),
                 })).isRequired,
                 name: PropTypes.string.isRequired,
                 value: PropTypes.number.isRequired,
@@ -48,7 +51,10 @@ export const pageQuery = graphql`
                     weight
                     value
                     reasons
-                    resolutions
+                    resolutions {
+                        text
+                        link
+                    }
                 }
                 name
                 value


### PR DESCRIPTION
This is using https://github.com/jenkins-infra/plugin-health-scoring/pull/452

The idea is to provide a guide on how to improve a specific score category. This can help maintainers but could also help contributors into providing the fix to the plugin repository.

<details>
<summary>Screenshot:</summary>

![Screenshot 2024-02-20 at 18 43 27](https://github.com/jenkins-infra/plugin-site/assets/985955/45c98917-d230-4175-a4d9-6eab0f7446df)

</details>

Not all categories have guidance on how to solve them.