### PR TITLE
Update renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
     "extends": [
-        "config:base",
-        "schedule:monthly"
+        "config:base"
     ],
     "labels": [
         "dependencies"


### PR DESCRIPTION
The change proposed updates the renovate schedule to run more frequent than on the first date of the month.
This repository has numerous dependencies and the first of the month doesn't suffice to tackle the entire log, causing a backlog becoming longer per month, I occasionally trigger by hand to empty the queue.