### PR TITLE
Display plugin score computation date

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/__mocks__/plugin-health-score.json
+++ b/plugins/gatsby-source-jenkinsplugins/__mocks__/plugin-health-score.json
@@ -2,6 +2,7 @@
     "plugins": {
         "aws-java-sdk-sns": {
             "value": 98,
+            "date": "2024-03-23T20:28:21.687022Z",
             "details": {
                 "security": {
                     "value": 100.0,

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.mjs.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.mjs.snap
@@ -229,6 +229,7 @@ exports[`utils get plugin healthScore data 1`] = `
 [
   {
     "children": [],
+    "date": 2024-03-23T20:28:21.687Z,
     "details": [
       {
         "components": [

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 import {load} from 'cheerio';
 import {execSync} from 'child_process';
 import axiosRetry, {exponentialDelay} from 'axios-retry';
-import {parse as parseDate} from 'date-fns';
+import {parse as parseDate, parseJSON} from 'date-fns';
 import PQueue from 'p-queue';
 import {parseStringPromise} from 'xml2js';
 import {createRequire} from 'module';
@@ -516,7 +516,7 @@ export const fetchPluginHealthScore = async ({createNode, reporter}) => {
     const baseURL = 'https://plugin-health.jenkins.io/api';
     const {plugins, statistics} = await requestGET({url: `${baseURL}/scores`, reporter});
     for (const pluginName of Object.keys(plugins)) {
-        const {value, details} = plugins[pluginName];
+        const {value, date, details} = plugins[pluginName];
         const detailsArray = [];
         for (const categoryName of Object.keys(details)) {
             detailsArray.push(
@@ -529,6 +529,7 @@ export const fetchPluginHealthScore = async ({createNode, reporter}) => {
 
         createNode({
             value,
+            date: parseJSON(date),
             details: detailsArray,
             id: pluginName,
             parent: null,

--- a/plugins/plugin-site/src/components/PluginHealthScore.css
+++ b/plugins/plugin-site/src/components/PluginHealthScore.css
@@ -1,3 +1,7 @@
+.pluginHealth > div:last-child {
+    margin-bottom: 2rem;
+}
+
 #pluginHealth--score {
     display: flex;
     align-items: center;

--- a/plugins/plugin-site/src/components/PluginHealthScore.jsx
+++ b/plugins/plugin-site/src/components/PluginHealthScore.jsx
@@ -129,7 +129,7 @@ function compareString(a, b) {
 
 function PluginHealthScore({healthScore: {value: score, date, details}}) {
     return (
-        <div className="container">
+        <div className="container pluginHealth">
             <div id="pluginHealth--score">
                 <div>
                     <div className="pluginHealth--score-title">

--- a/plugins/plugin-site/src/components/PluginHealthScore.jsx
+++ b/plugins/plugin-site/src/components/PluginHealthScore.jsx
@@ -1,7 +1,9 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import TimeAgo from 'react-timeago';
 
 import ucFirst from '../utils/ucfirst';
+import {formatter} from '../commons/helper';
 import './PluginHealthScore.css';
 
 function ScoreIcon({score, className}) {
@@ -125,7 +127,7 @@ function compareString(a, b) {
     return 0;
 }
 
-function PluginHealthScore({healthScore: {value: score, details}}) {
+function PluginHealthScore({healthScore: {value: score, date, details}}) {
     return (
         <div className="container">
             <div id="pluginHealth--score">
@@ -144,6 +146,11 @@ function PluginHealthScore({healthScore: {value: score, details}}) {
                     );
                 })}
             </div>
+
+            <div>
+                {'Computed: '}
+                <TimeAgo date={Date.parse(date)} formatter={formatter}/>
+            </div>
         </div>
     );
 }
@@ -151,6 +158,7 @@ function PluginHealthScore({healthScore: {value: score, details}}) {
 PluginHealthScore.propTypes = {
     healthScore: PropTypes.shape({
         value: PropTypes.number.isRequired,
+        date: PropTypes.string.isRequired,
         details: PropTypes.arrayOf(ScoreDetail.propTypes.data).isRequired
     }).isRequired,
 };

--- a/plugins/plugin-site/src/templates/plugin_healthScore.jsx
+++ b/plugins/plugin-site/src/templates/plugin_healthScore.jsx
@@ -20,6 +20,7 @@ TemplatePluginHealthScore.propTypes = {
         jenkinsPlugin: PropTypesJenkinsPlugin.isRequired,
         healthScore: PropTypes.shape({
             value: PropTypes.number.isRequired,
+            date: PropTypes.string.isRequired,
             details: PropTypes.arrayOf(PropTypes.shape({
                 components: PropTypes.arrayOf(PropTypes.shape({
                     max: PropTypes.number.isRequired,
@@ -46,6 +47,7 @@ export const pageQuery = graphql`
         }
 
         healthScore: jenkinsPluginHealthScore(id: {eq: $name}) {
+            date
             details {
                 components {
                     weight


### PR DESCRIPTION
Closes #1672.

Using https://github.com/jenkins-infra/plugin-health-scoring/pull/491, we can know when the score of a plugin was computed. 
This detail can be useful when trying to understand why a plugin improvement does not shows in a better score.

<details>
<summary>Example on Mailer plugin:</summary>

![Screenshot 2024-03-25 at 10-15-30 Mailer](https://github.com/jenkins-infra/plugin-site/assets/985955/00ed894b-c8de-407c-8cdf-f4cd0cd89572)
</details>

<details>
<summary>Example on Git plugin:</summary>

![Screenshot 2024-03-25 at 10-15-46 Git](https://github.com/jenkins-infra/plugin-site/assets/985955/c794415d-605a-4309-b833-3f915de496aa)
</details>
