### PR TITLE
Display message when no open issues

### DIFF
--- a/plugins/plugin-site/src/components/PluginIssues.jsx
+++ b/plugins/plugin-site/src/components/PluginIssues.jsx
@@ -44,7 +44,7 @@ function PluginIssues({pluginId}) {
                             </tr>
                         </thead>
                         <tbody>
-                            {issues.map(issue => (
+                            {issues && issues.map(issue => (
                                 <tr key={issue.key}>
                                     <th scope="row"><a href={issue.url}>{issue.key}</a></th>
                                     <td>{issue.summary}</td>

--- a/plugins/plugin-site/src/components/PluginIssues.jsx
+++ b/plugins/plugin-site/src/components/PluginIssues.jsx
@@ -29,7 +29,7 @@ function PluginIssues({pluginId}) {
 
     return (
         <div>
-            {issues.length === 0 ? (
+            {issues && issues.length === 0 ? (
                 <div>Currently, there are no open issues.</div>
             ) : (
                 <div className="table-responsive">

--- a/plugins/plugin-site/src/components/PluginIssues.jsx
+++ b/plugins/plugin-site/src/components/PluginIssues.jsx
@@ -29,31 +29,33 @@ function PluginIssues({pluginId}) {
 
     return (
         <div>
-            <div className="table-responsive">
-                <table className="table">
-                    <caption>List of issues</caption>
-                    <thead>
-                        <tr>
-                            <th scope="col">Key</th>
-                            <th scope="col">Summary</th>
-                            <th scope="col">Created</th>
-                            <th scope="col">Updated</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {issues && issues.map(issue => {
-                            return (
+            {issues.length === 0 ? (
+                <div>Currently, there are no open issues.</div>
+            ) : (
+                <div className="table-responsive">
+                    <table className="table">
+                        <caption>List of issues</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Key</th>
+                                <th scope="col">Summary</th>
+                                <th scope="col">Created</th>
+                                <th scope="col">Updated</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {issues.map(issue => (
                                 <tr key={issue.key}>
                                     <th scope="row"><a href={issue.url}>{issue.key}</a></th>
                                     <td>{issue.summary}</td>
-                                    <td><TimeAgo date={new Date(issue.created)} formatter={formatter}/></td>
-                                    <td><TimeAgo date={new Date(issue.updated)} formatter={formatter}/></td>
+                                    <td><TimeAgo date={new Date(issue.created)} formatter={formatter} /></td>
+                                    <td><TimeAgo date={new Date(issue.updated)} formatter={formatter} /></td>
                                 </tr>
-                            );
-                        })}
-                    </tbody>
-                </table>
-            </div>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Closes #1691 

Display a message when there are no open issues instead of showing an empty table.
Eg: [Console Column plugin](https://plugins.jenkins.io/console-column-plugin/issues/)

![isssue msg](https://github.com/jenkins-infra/plugin-site/assets/107404972/71ea6ca5-18b0-4258-9b37-e093db2f5078)
