### PR TITLE
Define the schema of JenkinsPluginHealthScore so it compiles even with scores report is down

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.mjs
@@ -76,6 +76,7 @@ export const createSchemaCustomization = ({actions}) => {
             details: [JenkinsPluginHealthScoreDetails]
             value: Int
         }
+
         type JenkinsPluginHealthScoreStatistics implements Node {
             average: Int
             minimum: Int

--- a/plugins/gatsby-source-jenkinsplugins/gatsby-node.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/gatsby-node.mjs
@@ -49,5 +49,41 @@ export const createSchemaCustomization = ({actions}) => {
             plugin: JenkinsPlugin @link(from: "name", by: "name")
             machineVersion: String @machineVersion(field: "version")
         }
+
+        type JenkinsPluginHealthScoreDetailsComponentsResolutions {
+            text: String
+            link: String
+        }
+
+        type JenkinsPluginHealthScoreDetailsComponents {
+            value: Int
+            weight: Int
+            reasons: [String]
+            resolutions: [JenkinsPluginHealthScoreDetailsComponentsResolutions]
+        }
+
+        type JenkinsPluginHealthScoreDetails {
+            value: Int
+            weight: Float
+            components: [JenkinsPluginHealthScoreDetailsComponents]
+            name: String
+        }
+
+        type JenkinsPluginHealthScore implements Node {
+            url: String
+            name: String
+            date: Date @dateformat
+            details: [JenkinsPluginHealthScoreDetails]
+            value: Int
+        }
+        type JenkinsPluginHealthScoreStatistics implements Node {
+            average: Int
+            minimum: Int
+            maximum: Int
+            firstQuartile: Int
+            median: Int
+            thirdQuartile: Int
+            name: String
+        }
     `);
 };


### PR DESCRIPTION
https://reports.jenkins.io/plugin-health-scoring/scores.json is 0 bytes, so since gatsby, by default, creates a schema based on createNode calls, the schema doesn't exist

So updating the plugin to have the schema pre-defined, which takes out some guesswork issues anyways

But since the report is down, and I can't see the results, I'm just guessing based on what i see https://plugin-health.jenkins.io/api/scores