### PR TITLE
Remove references to “instance”

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/__mocks__/plugin-doc.md
+++ b/plugins/gatsby-source-jenkinsplugins/__mocks__/plugin-doc.md
@@ -14,7 +14,7 @@ identities as user properties.
 
 ## Usage
 
-On my Jenkins instance, I'm authenticated as "nicolas". As I want to use
+On my Jenkins controller, I'm authenticated as "nicolas". As I want to use
 the same identity for commits on repositories, I can setup an additional
 identity for my account on googlecode :
 ![](docs/images/Capture_d’écran_2012-08-21_à_15.03.47.png)

--- a/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.mjs.snap
+++ b/plugins/gatsby-source-jenkinsplugins/__snapshots__/utils.test.mjs.snap
@@ -320,7 +320,7 @@ until you exactly have the same ID in jenkins and SCM.</p>
 This plugin uses this extension point to let user configure external
 identities as user properties.</p>
 <h2>Usage</h2>
-<p>On my Jenkins instance, I'm authenticated as "nicolas". As I want to use
+<p>On my Jenkins controller, I'm authenticated as "nicolas". As I want to use
 the same identity for commits on repositories, I can setup an additional
 identity for my account on googlecode :
 <img src="docs/images/Capture_d%E2%80%99%C3%A9cran_2012-08-21_%C3%A0_15.03.47.png" alt=""></p>

--- a/plugins/plugin-site/src/components/InstallInstructions.jsx
+++ b/plugins/plugin-site/src/components/InstallInstructions.jsx
@@ -29,7 +29,7 @@ function InstallInstructions({isShowInstructions, toggleShowInstructions, plugin
                         <a href="#releases" onClick={e=>{toggleShowInstructions(e);navigate(`/${pluginId}/releases/`);}}>
                             {'releases'}
                         </a>
-                        {' and upload it to your Jenkins instance.'}
+                        {' and upload it to your Jenkins controller.'}
                     </li>
                 </ol>
             </ModalBody>

--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -35,7 +35,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
                 <h4>{cleanTitle(title)}</h4>
             </div>
             <div className="Plugin--InstallsContainer">
-                {`Used by ${installStr} of instances`}
+                {`Used by ${installStr} of controllers`}
             </div>
             <div className="Plugin--VersionContainer">
                 <span className="jc">

--- a/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
+++ b/plugins/plugin-site/src/components/PluginReadableInstalls.jsx
@@ -7,7 +7,7 @@ function PluginReadableInstalls({currentInstalls, percentage}) {
         return <h5>No usage data available</h5>;
     }
     return (<h5 title={`Total: ${new Intl.NumberFormat('en-US').format(currentInstalls)}`}>
-        {`Installed on ${formatPercentage(percentage)} of\u{A0}instances`}
+        {`Installed on ${formatPercentage(percentage)} of\u{A0}controllers`}
     </h5>);
 }
 


### PR DESCRIPTION
This repository has a handful of references to a Jenkins “instance,” a particularly irritating term that has neither a clear meaning nor a definition in [the glossary](https://www.jenkins.io/doc/book/glossary/). (The only clear concept of “instance” in the Jenkins ecosystem is [Instance Identity](https://plugins.jenkins.io/instance-identity/), which is an internal implementation detail that is likely out of scope for most documentation.) This PR replaces the term with the more clearly-defined “controller.”