### PR TITLE
Use dark theme variables from Jenkins.io

### DIFF
--- a/plugins/plugin-site/gatsby-config.mjs
+++ b/plugins/plugin-site/gatsby-config.mjs
@@ -61,8 +61,7 @@ config.plugins = [
                 '@import \'./styles/base.css\';',
                 '@import \'./styles/font-icons.css\';',
                 '@import \'github-syntax-light/lib/github-light.css\';',
-                '@import \'github-syntax-dark/lib/github-auto.css\';',
-                '@import \'https://www.jenkins.io/stylesheets/styles.css\';'
+                '@import \'github-syntax-dark/lib/github-auto.css\';'
             ],
         },
     },

--- a/plugins/plugin-site/gatsby-config.mjs
+++ b/plugins/plugin-site/gatsby-config.mjs
@@ -61,7 +61,8 @@ config.plugins = [
                 '@import \'./styles/base.css\';',
                 '@import \'./styles/font-icons.css\';',
                 '@import \'github-syntax-light/lib/github-light.css\';',
-                '@import \'github-syntax-dark/lib/github-auto.css\';'
+                '@import \'github-syntax-dark/lib/github-auto.css\';',
+                '@import \'https://www.jenkins.io/stylesheets/styles.css\';'
             ],
         },
     },

--- a/plugins/plugin-site/src/components/PluginPageLayout.jsx
+++ b/plugins/plugin-site/src/components/PluginPageLayout.jsx
@@ -50,7 +50,7 @@ function PluginPageLayout({plugin, children}) {
                 <h1 className="title">
                     {cleanTitle(plugin.title)}
                 </h1>
-                <button className="btn btn-secondary" onClick={toggleShowInstructions}>
+                <button className="app-button" onClick={toggleShowInstructions}>
                     How to install
                 </button>
                 <InstallInstructions isShowInstructions={isShowInstructions}

--- a/plugins/plugin-site/src/styles/base.css
+++ b/plugins/plugin-site/src/styles/base.css
@@ -1412,9 +1412,6 @@ a.card:hover {
 
 @media (prefers-color-scheme: dark) {
   body {
-    --color: #dee2e6;
-    --background: #212529;
-    --link-color: #6ea8fe;
     --no-labels-background: #212529;
     --code-background: #111;
     --search-background: #313539;


### PR DESCRIPTION
Jenkins.io's stylesheet now includes variables for dark theme, this PR updates the plugin site to use them for consistency. Also updates the 'How to install' button to use the button class from Jenkins.io.

##### Before
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a6d59416-6298-4c27-a309-d053774fc711">

##### After
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/cdc537b1-c6a5-4710-95cf-f61f3761964d">
