### PR TITLE
fix(utils.mjs) use the old stats.jenkins.io website (temporarily?)

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -30,7 +30,7 @@ const requestGET = async ({url, reporter}) => {
 
     try {
         const results = await axios.get(url);
-        if (results.status !== 200) {
+        if (results.status >= 400) {
             throw results.data;
         }
         return results.data;

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -434,13 +434,13 @@ export const fetchSiteInfo = async ({createNode, reporter}) => {
 
 export const fetchStats = async ({reporter, stats}) => {
     const timeSpan = 12;
-    const totalUrl = 'https://stats.jenkins.io/jenkins-stats/svg/total-jenkins.csv';
+    const totalUrl = 'https://old.stats.jenkins.io/jenkins-stats/svg/total-jenkins.csv';
     const totalInstalls = (await requestGET({url: totalUrl, reporter})).trim().split('\n');
     stats.core = {installations: []};
     const timestamps = [];
     for (let monthsAgo = 1; monthsAgo <= timeSpan; monthsAgo++) {
         const [month, coreInstalls] = csvParse(totalInstalls[totalInstalls.length - monthsAgo]);
-        const pluginInstallsUrl = `https://stats.jenkins.io/jenkins-stats/svg/${month}-plugins.csv`;
+        const pluginInstallsUrl = `https://old.stats.jenkins.io/jenkins-stats/svg/${month}-plugins.csv`;
         const timestamp = Date.parse(`${month}`.replace(/(..)$/, '-$1'));
         timestamps.push(timestamp);
         const pluginInstalls = (await requestGET({url: pluginInstallsUrl, reporter})).split('\n');

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -29,7 +29,7 @@ const requestGET = async ({url, reporter}) => {
     activity.start();
 
     try {
-        const results = await axios.get(url, { maxRedirects: 10 });
+        const results = await axios.get(url);
         if (results.status !== 200) {
             throw results.data;
         }

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -29,7 +29,7 @@ const requestGET = async ({url, reporter}) => {
     activity.start();
 
     try {
-        const results = await axios.get(url);
+        const results = await axios.get(url, { maxRedirects: 10 });
         if (results.status !== 200) {
             throw results.data;
         }

--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -30,7 +30,7 @@ const requestGET = async ({url, reporter}) => {
 
     try {
         const results = await axios.get(url);
-        if (results.status >= 400) {
+        if (results.status !== 200) {
             throw results.data;
         }
         return results.data;


### PR DESCRIPTION
The plugin site generation fails since https://github.com/jenkins-infra/helpdesk/issues/4265 was applied earlier today.

This PR is a short term fix to use the old stats website, still available through http://old.stats.jenkins.io (and still updated).

These files will have to be served in the new website

cc @lemeurherve @lemeurherveCB @krisstern @MarkEWaite for info