### PR TITLE
use the old stats.jenkins.io website (temporarily?)

### DIFF
--- a/plugins/plugin-site/src/components/PluginPageLayout.jsx
+++ b/plugins/plugin-site/src/components/PluginPageLayout.jsx
@@ -85,7 +85,7 @@ function PluginPageLayout({plugin, children}) {
                             <div className="chart">
                                 <LineChart installations={plugin.stats.installations} />
                             </div>
-                            <div className="label-link"><a href={`https://stats.jenkins.io/pluginversions/${plugin.name}.html`}>View detailed version information</a></div>
+                            <div className="label-link"><a href={`https://old.stats.jenkins.io/pluginversions/${plugin.name}.html`}>View detailed version information</a></div>
                         </>}
                     </div>
                     <div className="sidebarSection">


### PR DESCRIPTION
Continues from https://github.com/jenkins-infra/plugin-site/pull/1890

Related with https://github.com/jenkins-infra/helpdesk/issues/4265