### PR TITLE
Revert "fix(utils.mjs) use the old stats.jenkins.io website (temporarily?)"

### DIFF
--- a/plugins/gatsby-source-jenkinsplugins/utils.mjs
+++ b/plugins/gatsby-source-jenkinsplugins/utils.mjs
@@ -435,13 +435,13 @@ export const fetchSiteInfo = async ({createNode, reporter}) => {
 
 export const fetchStats = async ({reporter, stats}) => {
     const timeSpan = 12;
-    const totalUrl = 'https://old.stats.jenkins.io/jenkins-stats/svg/total-jenkins.csv';
+    const totalUrl = 'https://stats.jenkins.io/jenkins-stats/svg/total-jenkins.csv';
     const totalInstalls = (await requestGET({url: totalUrl, reporter})).trim().split('\n');
     stats.core = {installations: []};
     const timestamps = [];
     for (let monthsAgo = 1; monthsAgo <= timeSpan; monthsAgo++) {
         const [month, coreInstalls] = csvParse(totalInstalls[totalInstalls.length - monthsAgo]);
-        const pluginInstallsUrl = `https://old.stats.jenkins.io/jenkins-stats/svg/${month}-plugins.csv`;
+        const pluginInstallsUrl = `https://stats.jenkins.io/jenkins-stats/svg/${month}-plugins.csv`;
         const timestamp = Date.parse(`${month}`.replace(/(..)$/, '-$1'));
         timestamps.push(timestamp);
         const pluginInstalls = (await requestGET({url: pluginInstallsUrl, reporter})).split('\n');


### PR DESCRIPTION
Reverts jenkins-infra/plugin-site#1890 as the new stats.jenkins.io is now serving existing files.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132