### PR TITLE
chore(Jenkinsfile) capture azcopy logs when deployment fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,12 +146,17 @@ pipeline {
               --put-md5 \
               --local-hash-storage-mode=HiddenFiles \
               ./plugins/plugin-site/public/ "${FILESHARE_SIGNED_URL}"
-
-            # Retrieve azcopy logs to archive them
-            cat /home/jenkins/.azcopy/*.log > azcopy.log
             '''
-            archiveArtifacts 'azcopy.log'
           }
+        }
+      }
+      post {
+        failure {
+          // Retrieve azcopy logs and archive them when deployment fails
+          sh '''
+          cat /home/jenkins/.azcopy/*.log > azcopy.log
+          '''
+          archiveArtifacts 'azcopy.log'
         }
       }
     }


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4379, it appeared that the azcopy failing logs weren't collected due to pipeline code mistake (logs collection instructions are never reached).

This PR aims at fixing this problem to allow admins to debug the failing deployment