### PR TITLE
Fix for issue #4522 | Broken Thank you message in Firefox

### DIFF
--- a/plugins/plugin-site/src/components/ThankAContributorNote.jsx
+++ b/plugins/plugin-site/src/components/ThankAContributorNote.jsx
@@ -137,7 +137,7 @@ function ThankAContributorNote() {
                             ? 'repos'
                             : 'repo'}{' '}
                         in{' '}
-                        {dayjs(thankYou['MONTH']?.replace(/['"]+/g, '')).format(
+                        {dayjs(thankYou['MONTH']?.replace(/['"]+/g, '').trim()).format(
                             'MMMM YYYY'
                         )}
                         !


### PR DESCRIPTION
## Remove extra whitespace
`thankYou['MONTH']?.replace(/['"]+/g, '')` had a value ` 2024-12`. It contained a leading space which marked it as invalid date in firefox. So I made sure the string is trimmed of white spaces.

### Before
![Before the fix](https://github.com/user-attachments/assets/5a9fb06a-c4ca-4305-9749-0240297168ba)

### After
![After the fix](https://github.com/user-attachments/assets/61adb603-581d-4be3-87d3-94a9e869a516)


For the issue jenkins-infra/helpdesk#4522