### PR TITLE
search result links and cleans up the unused variables in layout.jsx

### DIFF
--- a/plugins/plugin-site/src/components/Plugin.jsx
+++ b/plugins/plugin-site/src/components/Plugin.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {navigate} from 'gatsby';
 import {cleanTitle, formatPercentage} from '../commons/helper';
 import Icon from '../components/Icon';
 import PluginLabels from '../components/PluginLabels';
@@ -27,7 +26,7 @@ Developers.propTypes = PluginDevelopers.propTypes;
 function Plugin({plugin: {name, title, stats, labels, excerpt, developers, buildDate, releaseTimestamp, healthScore}}) {
     const installStr = stats.currentInstallPercentage ? formatPercentage(stats.currentInstallPercentage) : '?';
     return (
-        <div onClick={() => navigate(`/${name}/`)} className="Plugin--PluginContainer">
+        <a href={`/${name}/`} className="Plugin--PluginContainer">
             <div className="Plugin--IconContainer">
                 <Icon title={title} />
             </div>
@@ -52,7 +51,7 @@ function Plugin({plugin: {name, title, stats, labels, excerpt, developers, build
             <div className="Plugin--HealthScoreContainer">
                 {healthScore && (<PluginHealthScoreProgressBar healthScore={healthScore} name={name}/>)}
             </div>
-        </div>
+        </a>
     );
 }
 


### PR DESCRIPTION
Issue: #2352 

PR Title: feat: Allow search results to open in new tab and fix lint warnings

This PR fixes the search result links and cleans up the unused variables in layout.jsx.

1. Enables Opening Search Results in a New Tab

Currently, the search result items on the plugin index page are rendered as div elements with an onClick handler. This prevents users from using standard browser functionality like middle-clicking or Ctrl+Click to open plugin pages in a new tab, which is frustrating for users who want to compare multiple plugins.

This change replaces the div with a standard HTML <a> tag, restoring the expected browser behavior and improving usability.

[Fix video.zip](https://github.com/user-attachments/files/22198674/Fix.video.zip)

2. Removes Unused Variables in layout.jsx
The layout.jsx component contained two unused variables (buildTime and siteUrl) that were triggering ESLint no-unused-vars warnings during development. This change removes the unused variables, cleaning up the code and resolving the linting errors.