### PR TITLE
hotfix: disable Algolia index publication until account issue is resolved

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,8 @@ pipeline {
         NODE_ENV = 'production'
         GATSBY_ALGOLIA_APP_ID = credentials('algolia-plugins-app-id')
         GATSBY_ALGOLIA_SEARCH_KEY = credentials('algolia-plugins-search-key')
-        GATSBY_ALGOLIA_WRITE_KEY = credentials('algolia-plugins-write-key')
+        // TODO: restore when plugin site Algolia account is unblocked, see https://github.com/jenkins-infra/helpdesk/issues/5066
+        // GATSBY_ALGOLIA_WRITE_KEY = credentials('algolia-plugins-write-key')
       }
       steps {
         sh 'yarn build'


### PR DESCRIPTION
This change comments out `GATSBY_ALGOLIA_WRITE_KEY` to build the plugin website without the algolia index part.

Refs:
- https://github.com/jenkins-infra/plugin-site/blob/28cc9c1d2adbc4a80a9dd2b553e3824a68a4ccc0/plugins/plugin-site/gatsby-config.mjs#L144-L151
- https://github.com/jenkins-infra/helpdesk/issues/5066#issuecomment-4244133000