### PR TITLE
chore(Jenkinsfile): remove asdf, rely on packer-images node.js

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,13 +32,19 @@ pipeline {
       }
     }
 
+    stage('Check Tooling') {
+      steps {
+        sh 'node --version'
+        sh 'npm --version'
+      }
+    }
+
     stage('Install dependencies') {
       environment {
         NODE_ENV = 'development'
       }
       steps {
         sh '''
-        asdf install
         npm install --global yarn
         yarn install
         '''


### PR DESCRIPTION
Ref:
- jenkins-infra/helpdesk#5093

Remove ASDF from the plugin-site build and rely on the Node.js version installed on packer-images agents (tracked by updatecli).
