### PR TITLE
Add support for a single affected version in the range

### DIFF
--- a/plugins/plugin-site/src/components/PluginReadableVersion.jsx
+++ b/plugins/plugin-site/src/components/PluginReadableVersion.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 function PluginReadableVersion({version, active}) {
     if (version.firstVersion && version.lastVersion) {
-        return <>{`Affects version ${version.firstVersion} to ${version.lastVersion}`}</>;
+        if (version.firstVersion === version.lastVersion) {
+            return <>{`Affects only version ${version.firstVersion}`}</>;
+        } else {
+            return <>{`Affects version ${version.firstVersion} to ${version.lastVersion}`}</>;
+        }
     } else if (version.firstVersion && active) {
         return <>{`Affects version ${version.lastVersion} and later`}</>;
     } else if (version.lastVersion) {


### PR DESCRIPTION
Untested.

E.g. https://plugins.jenkins.io/gatling/ is looking pretty silly:

<img width="489" height="226" alt="image" src="https://github.com/user-attachments/assets/35ecce32-bb83-427c-a6b9-2a574cfcb8e0" />
