### PR TITLE
chore(pipeline) retry PR deployment stage once when the Netlify deployment fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,6 +83,9 @@ pipeline {
     }
 
     stage('Deploy to preview site') {
+      options {
+        retry(2)
+      }
       when {
         allOf {
           changeRequest()


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5219

Tested with a replay in https://infra.ci.jenkins.io/job/website-jobs/job/plugin-site/view/change-requests/job/PR-2572/2/ with success


It's a tiny patch but should be good enough.